### PR TITLE
New helper method to clear new persistence location with Core 4.2.0

### DIFF
--- a/Sources/FileManager+Testable.swift
+++ b/Sources/FileManager+Testable.swift
@@ -32,26 +32,25 @@ public extension FileManager {
         }
     }
     
-    /// Removes the Adobe-specific directory within the app's data storage (persistence). This method attempts to locate and delete the 
-    /// `com.adobe.aep.datastore` directory either in the specified app group's container directory or in the default library directory 
+    /// Removes the Adobe cache directory within the app's data storage (persistence) from the specified app group's container directory or in the default library directory
     /// if no app group is provided.
     ///
-    /// - Parameter appGroup: An optional `String` representing the app group identifier. If provided, the method will look for the Adobe directory within the shared container for that app group. If `nil`, the method will search for the directory in the user's library directory across all domains the app has access to.
-    ///
+    /// - Parameters:
+    ///   - directoryName: A `String` specifying the name of the directory to remove. Defaults to `"com.adobe.aep.datastore"` if not specified.
+    ///   - appGroup: An optional `String` representing the app group identifier. If provided, the method will look for the directory within the app group container. If `nil`, the method will search in the current application's library directory.
     /// - Requires: Before calling this method, ensure that the caller has the appropriate permissions to access and modify the file system, especially if working with app group directories.
-    func removeAdobeDirectory(appGroup: String?) {
+    func removeAdobeCacheDirectory(_ directoryName: String = "com.adobe.aep.datastore", with appGroup: String? = nil) {
         let LOG_TAG = "FileManager"
-        let adobeDirectory = "com.adobe.aep.datastore"
         let fileManager = FileManager.default
 
         // Recreate the directory URL
         var directoryUrl: URL?
         if let appGroup = appGroup {
             directoryUrl = fileManager.containerURL(forSecurityApplicationGroupIdentifier: appGroup)?
-                .appendingPathComponent(adobeDirectory, isDirectory: true)
+                .appendingPathComponent(directoryName, isDirectory: true)
         } else {
             directoryUrl = fileManager.urls(for: .libraryDirectory, in: .allDomainsMask).first?
-                .appendingPathComponent(adobeDirectory, isDirectory: true)
+                .appendingPathComponent(directoryName, isDirectory: true)
         }
 
         guard let directoryUrl = directoryUrl else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With the recent [update to Core (v4.2.0)](https://github.com/adobe/aepsdk-core-ios/releases/tag/4.2.0) which migrated the persistence location from `UserDefaults` to the device file system, the old helper utility extension on `UserDefaults` no longer works to clear persistence correctly between test case runs. This PR addresses this gap in functionality by creating a new helper utility extension on FileManager that:
1. Recreates the directory URL using an optional app group value
    * See construction of URL in Core's `FileSystemNamedCollection` [`findOrCreateAdobeSubdirectory`](https://github.com/adobe/aepsdk-core-ios/blob/da278f9f350f001f768cb2a01f7389f6af671140/AEPServices/Sources/storage/FileSystemNamedCollection.swift#L130C18-L130C47)
2. Attempts to remove the directory entirely, thereby clearing persistence

## Questions for reviewers
1. Is it appropriate for this method to be added as an extension to `FileManager`? I considered making it part of the existing UserDefaults [`clearAll`](https://github.com/adobe/aepsdk-testutils-ios/blob/dda383317d44541e7186d806a9ca33a662197756/Sources/UserDefaults%2BTest.swift#L17) helper but decided against it for the following reasons:
    1. We want to migrate off usage of UserDefaults APIs completely eventually (soon), so bundling the functionality adds additional tech debt
    2. The actual storage/removal logic depends on FileManager
2. Should the `appGroup` param have a default arg of `nil`?
    1. It doesn't seem like a common occurrence for test classes to make use of the `appGroup`

## Usage 
Simply add a line that calls the new method on `FileManager.default` (example of teardown process in `TestBase`):
```swift
public override func tearDown() {
    super.tearDown()

    // wait .2 seconds in case there are unexpected events that were in the dispatch process during cleanup
    usleep(200000)
    resetTestExpectations()
    FunctionalTestBase.isFirstRun = false
    EventHub.reset()
    UserDefaults.clearAll()
    FileManager.default.clearCache()
    FileManager.default.removeAdobeDirectory(appGroup: nil) // <-- new method! - usage example
}
```

Also see example usage of the test utils in action here: https://github.com/adobe/aepsdk-messaging-ios/pull/229

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
