### PR TITLE
Create new NodeConfig class to handle JSON comparison options

### DIFF
--- a/AEPTestUtils.xcodeproj/project.pbxproj
+++ b/AEPTestUtils.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		4C0293C22AE1D9AD0093CCBA /* XCTestCase+AnyCodableAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0293C12AE1D9AD0093CCBA /* XCTestCase+AnyCodableAsserts.swift */; };
 		4C7043472AF45A98008CF67D /* EventSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7043462AF45A98008CF67D /* EventSpec.swift */; };
 		4C7043492AF45B05008CF67D /* URL+Testable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7043482AF45B05008CF67D /* URL+Testable.swift */; };
+		4C70434C2AFB0D4F008CF67D /* AnyCodableAssertsParameterizedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C70434A2AFB0D4F008CF67D /* AnyCodableAssertsParameterizedTests.swift */; };
+		4C70434D2AFB0D4F008CF67D /* AnyCodableAssertsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C70434B2AFB0D4F008CF67D /* AnyCodableAssertsTests.swift */; };
 		4C9CF7C82AE20A7300EB88D4 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C9CF7C72AE20A7300EB88D4 /* XCTest.framework */; };
 		72EC4ED272DA96D1B2F44F4D /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E05720B5778E784DC19DA9C /* Pods_UnitTests.framework */; };
 		D4ABABAE251A7D95008076BF /* AEPTestUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D444995F2519506B0093B364 /* AEPTestUtils.framework */; };
@@ -101,6 +103,8 @@
 		4C0293C12AE1D9AD0093CCBA /* XCTestCase+AnyCodableAsserts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AnyCodableAsserts.swift"; sourceTree = "<group>"; };
 		4C7043462AF45A98008CF67D /* EventSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSpec.swift; sourceTree = "<group>"; };
 		4C7043482AF45B05008CF67D /* URL+Testable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Testable.swift"; sourceTree = "<group>"; };
+		4C70434A2AFB0D4F008CF67D /* AnyCodableAssertsParameterizedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodableAssertsParameterizedTests.swift; sourceTree = "<group>"; };
+		4C70434B2AFB0D4F008CF67D /* AnyCodableAssertsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodableAssertsTests.swift; sourceTree = "<group>"; };
 		4C9CF7C72AE20A7300EB88D4 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		D444995F2519506B0093B364 /* AEPTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AEPTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4967534251130D3001F5F95 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -196,6 +200,8 @@
 		D4D5B4F1242EBD2200CAB6E4 /* UnitTests */ = {
 			isa = PBXGroup;
 			children = (
+				4C70434A2AFB0D4F008CF67D /* AnyCodableAssertsParameterizedTests.swift */,
+				4C70434B2AFB0D4F008CF67D /* AnyCodableAssertsTests.swift */,
 				D4D5B5252432599B00CAB6E4 /* Info.plist */,
 			);
 			name = UnitTests;
@@ -286,6 +292,7 @@
 					};
 					D4D5B5202432599B00CAB6E4 = {
 						CreatedOnToolsVersion = 11.3.1;
+						LastSwiftMigration = 1500;
 					};
 				};
 			};
@@ -457,6 +464,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4C70434C2AFB0D4F008CF67D /* AnyCodableAssertsParameterizedTests.swift in Sources */,
+				4C70434D2AFB0D4F008CF67D /* AnyCodableAssertsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -697,6 +706,7 @@
 			baseConfigurationReference = DD5E7AA3DFCAE33634061318 /* Pods-UnitTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = FKGEE875K4;
 				INFOPLIST_FILE = Tests/UnitTests/Info.plist;
@@ -708,6 +718,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.adobe.UnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 10.0;
@@ -719,6 +730,7 @@
 			baseConfigurationReference = FA085216E06413034AC11F06 /* Pods-UnitTests.release.xcconfig */;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = FKGEE875K4;
 				INFOPLIST_FILE = Tests/UnitTests/Info.plist;

--- a/AEPTestUtils.xcodeproj/project.pbxproj
+++ b/AEPTestUtils.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		4C70434C2AFB0D4F008CF67D /* AnyCodableAssertsParameterizedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C70434A2AFB0D4F008CF67D /* AnyCodableAssertsParameterizedTests.swift */; };
 		4C70434D2AFB0D4F008CF67D /* AnyCodableAssertsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C70434B2AFB0D4F008CF67D /* AnyCodableAssertsTests.swift */; };
 		4C9CF7C82AE20A7300EB88D4 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C9CF7C72AE20A7300EB88D4 /* XCTest.framework */; };
+		4CE14ECC2AFDC7F100969B36 /* NodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE14ECB2AFDC7F100969B36 /* NodeConfig.swift */; };
 		72EC4ED272DA96D1B2F44F4D /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E05720B5778E784DC19DA9C /* Pods_UnitTests.framework */; };
 		D4ABABAE251A7D95008076BF /* AEPTestUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D444995F2519506B0093B364 /* AEPTestUtils.framework */; };
 		E6CACBEEB618C1273B24F1AE /* Pods_AEPTestUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34C185B9927DF9E0701D766B /* Pods_AEPTestUtils.framework */; };
@@ -106,6 +107,7 @@
 		4C70434A2AFB0D4F008CF67D /* AnyCodableAssertsParameterizedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodableAssertsParameterizedTests.swift; sourceTree = "<group>"; };
 		4C70434B2AFB0D4F008CF67D /* AnyCodableAssertsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodableAssertsTests.swift; sourceTree = "<group>"; };
 		4C9CF7C72AE20A7300EB88D4 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		4CE14ECB2AFDC7F100969B36 /* NodeConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NodeConfig.swift; sourceTree = "<group>"; };
 		D444995F2519506B0093B364 /* AEPTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AEPTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D4967534251130D3001F5F95 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D4ABABDA251A8142008076BF /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
@@ -192,6 +194,7 @@
 				4C7043482AF45B05008CF67D /* URL+Testable.swift */,
 				4C0293AA2AE1D4550093CCBA /* UserDefaults+Test.swift */,
 				4C0293C12AE1D9AD0093CCBA /* XCTestCase+AnyCodableAsserts.swift */,
+				4CE14ECB2AFDC7F100969B36 /* NodeConfig.swift */,
 				D4967534251130D3001F5F95 /* Info.plist */,
 			);
 			path = Sources;
@@ -457,6 +460,7 @@
 				4C7043472AF45A98008CF67D /* EventSpec.swift in Sources */,
 				4C0293B72AE1D4550093CCBA /* TestableExtensionRuntime.swift in Sources */,
 				4C0293B22AE1D4550093CCBA /* FileManager+Testable.swift in Sources */,
+				4CE14ECC2AFDC7F100969B36 /* NodeConfig.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/NetworkRequestHelper.swift
+++ b/Sources/NetworkRequestHelper.swift
@@ -209,7 +209,7 @@ class NetworkRequestHelper {
     }
 }
 
-extension NetworkRequest {
+public extension NetworkRequest {
     convenience init?(urlString: String, httpMethod: HttpMethod) {
         guard let url = URL(string: urlString) else {
             assertionFailure("Unable to convert the provided string \(urlString) to URL")

--- a/Sources/NodeConfig.swift
+++ b/Sources/NodeConfig.swift
@@ -149,23 +149,20 @@ public class NodeConfig: Hashable {
          options: [OptionKey: Config] = [:],
          subtreeOptions: [OptionKey: Config],
          children: Set<NodeConfig> = []) {
+        // Validate subtreeOptions has every option defined
+        var validatedSubtreeOptions = subtreeOptions
+        for key in OptionKey.allCases {
+            if let foundConfig = subtreeOptions[key] {
+                continue
+            }
+            // If key is missing, add a default value
+            validatedSubtreeOptions[key] = Config(isActive: false)
+        }
+        
         self.name = name
         self.options = options
-        self.subtreeOptions = subtreeOptions
+        self.subtreeOptions = validatedSubtreeOptions
         self.children = children
-    }
-    
-    init(name: String?,
-         wildcardMatch: Config? = nil,
-         collectionEqualCount: Config? = nil,
-         primitiveExactMatch: Config? = nil,
-         children: Set<NodeConfig> = []) {
-
-        self.name = name
-        self.children = children
-        self.options[.wildcardMatch] = wildcardMatch
-        self.options[.collectionEqualCount] = collectionEqualCount
-        self.options[.primitiveExactMatch] = primitiveExactMatch
     }
     
     // Implementation of Hashable

--- a/Sources/NodeConfig.swift
+++ b/Sources/NodeConfig.swift
@@ -1,0 +1,609 @@
+//
+// Copyright 2023 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+
+import Foundation
+import XCTest
+
+public protocol MultiPathConfig {
+    var paths: [String?] { get }
+    var optionKey: NodeConfig.OptionKey { get }
+    var isActive: Bool { get }
+    var scope: NodeConfig.Scope { get }
+}
+
+struct PathConfig {
+    var path: String?
+    var optionKey: NodeConfig.OptionKey
+    var isActive: Bool
+    var scope: NodeConfig.Scope
+}
+
+public struct WildcardMatch: MultiPathConfig {
+    public let paths: [String?]
+    public let optionKey: NodeConfig.OptionKey = .wildcardMatch
+    public let isActive: Bool
+    public let scope: NodeConfig.Scope
+    
+    public init(paths: [String?], isActive: Bool = true, scope: NodeConfig.Scope = .singleNode) {
+        self.paths = paths
+        self.isActive = isActive
+        self.scope = scope
+    }
+    
+    public init(paths: String?..., isActive: Bool = true, scope: NodeConfig.Scope = .singleNode) {
+        self.init(paths: paths, isActive: isActive, scope: scope)
+    }
+}
+
+public struct CollectionEqualCount: MultiPathConfig {
+    public let paths: [String?]
+    public let optionKey: NodeConfig.OptionKey = .collectionEqualCount
+    public let isActive: Bool
+    public let scope: NodeConfig.Scope
+
+    public init(paths: [String?], isActive: Bool = true, scope: NodeConfig.Scope = .singleNode) {
+        self.paths = paths
+        self.isActive = isActive
+        self.scope = scope
+    }
+    
+    public init(paths: String?..., isActive: Bool = true, scope: NodeConfig.Scope = .singleNode) {
+        self.init(paths: paths, isActive: isActive, scope: scope)
+    }
+}
+
+public struct ValueExactMatch: MultiPathConfig {
+    public let paths: [String?]
+    public let optionKey: NodeConfig.OptionKey = .primitiveExactMatch
+    public let isActive: Bool = true
+    public let scope: NodeConfig.Scope
+    
+    public init(paths: [String?], scope: NodeConfig.Scope = .singleNode) {
+        self.paths = paths
+        self.scope = scope
+    }
+    
+    public init(paths: String?..., scope: NodeConfig.Scope = .singleNode) {
+        self.init(paths: paths, scope: scope)
+    }
+}
+
+public struct ValueTypeMatch: MultiPathConfig {
+    public let paths: [String?]
+    public let optionKey: NodeConfig.OptionKey = .primitiveExactMatch
+    public let isActive: Bool = false
+    public let scope: NodeConfig.Scope
+
+    public init(paths: [String?], scope: NodeConfig.Scope = .singleNode) {
+        self.paths = paths
+        self.scope = scope
+    }
+    
+    public init(paths: String?..., scope: NodeConfig.Scope = .singleNode) {
+        self.init(paths: paths, scope: scope)
+    }
+}
+
+public class NodeConfig: Hashable {
+    public enum Scope: String, Hashable {
+        case singleNode
+        case subtree
+    }
+    
+    public enum OptionKey: String, Hashable {
+        case wildcardMatch
+        case collectionEqualCount // should this be broken into both options behind the scenes?
+        case primitiveExactMatch
+        // Add other keys as needed
+        // var nullOrGivenType: Config?
+        // var caseSensitivity: Config?
+        // arrayEqualCount
+        // dictionaryEqualCount
+    }
+    
+    public struct Config: Hashable {
+        // required because all options are toggles and presnece of scope is not enough to determine what type of option should be applied
+        var isActive: Bool
+    }
+    
+    public enum NodeOption {
+        case option(OptionKey, Config, Scope)
+    }
+    
+    let name: String?
+    /// options set for this node
+    private(set) var options: [OptionKey: Config] = [:]
+    /// options set for the subtree given no options set for the node
+    private var subtreeOptions: [OptionKey: Config] = [:]
+    private(set) var children: Set<NodeConfig>
+
+    // Strongly-typed accessors for each option
+    var wildcardMatch: Config {
+        get { options[.wildcardMatch] ?? subtreeOptions[.wildcardMatch]! }
+        set { options[.wildcardMatch] = newValue }
+    }
+
+    var collectionEqualCount: Config {
+        get { options[.collectionEqualCount] ?? subtreeOptions[.collectionEqualCount]! }
+        set { options[.collectionEqualCount] = newValue }
+    }
+
+    var primitiveExactMatch: Config {
+        get { options[.primitiveExactMatch] ?? subtreeOptions[.primitiveExactMatch]! }
+        set { options[.primitiveExactMatch] = newValue }
+    }
+    
+    // TODO: implement default values checks for each option
+    // better param strictness based on usage expectation
+    init(name: String?,
+         options: [OptionKey: Config] = [:],
+         subtreeOptions: [OptionKey: Config],
+         children: Set<NodeConfig> = []) {
+        self.name = name
+        self.options = options
+        self.subtreeOptions = subtreeOptions
+        self.children = children
+    }
+    
+    init(name: String?,
+         wildcardMatch: Config? = nil,
+         collectionEqualCount: Config? = nil,
+         primitiveExactMatch: Config? = nil,
+         children: Set<NodeConfig> = []) {
+
+        self.name = name
+        self.children = children
+        self.options[.wildcardMatch] = wildcardMatch
+        self.options[.collectionEqualCount] = collectionEqualCount
+        self.options[.primitiveExactMatch] = primitiveExactMatch
+    }
+    
+    // Implementation of Hashable
+    public static func == (lhs: NodeConfig, rhs: NodeConfig) -> Bool {
+        // Define equality based on properties of NodeConfig
+        return lhs.name == rhs.name &&
+               lhs.options == rhs.options &&
+               lhs.subtreeOptions == rhs.subtreeOptions &&
+               lhs.children == rhs.children
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+        hasher.combine(options)
+        hasher.combine(subtreeOptions)
+        hasher.combine(children)
+    }
+    
+    func getChild(named name: String?) -> NodeConfig? {
+        return children.first(where: { $0.name == name })
+    }
+    
+    static func resolveOption(_ option: OptionKey, for node: NodeConfig?, parent parentNode: NodeConfig) -> NodeConfig.Config {
+        // Check node's node-specific option
+        if let nodeOption = node?.options[option] {
+            return nodeOption
+        }
+        // Check array's node-specific option
+        if let arrayOption = parentNode.options[option] {
+            return arrayOption
+        }
+        // Check node's subtree option, falling back to array node's default subtree config
+        switch option {
+        case .collectionEqualCount:
+            return node?.collectionEqualCount ?? parentNode.collectionEqualCount
+        case .primitiveExactMatch:
+            return node?.primitiveExactMatch ?? parentNode.primitiveExactMatch
+        case .wildcardMatch:
+            return node?.wildcardMatch ?? parentNode.wildcardMatch
+        }
+    }
+    
+    func createOrUpdateNode(using multiPathConfig: MultiPathConfig) {
+        let pathConfigs = multiPathConfig.paths.map({ PathConfig(path: $0, optionKey: multiPathConfig.optionKey, isActive: multiPathConfig.isActive, scope: multiPathConfig.scope) })
+        for pathConfig in pathConfigs {
+            createOrUpdateNode(using: pathConfig)
+        }
+    }
+    
+    // Helper method to create or traverse nodes
+    func createOrUpdateNode(using pathConfig: PathConfig) {
+        var current = self
+        
+        let path = pathConfig.path
+        let keyPath = getKeyPathComponents(from: path)
+        
+        // Inline function to find or create a child node
+        func findOrCreateChildNode(named name: String) -> NodeConfig {
+            let child: NodeConfig
+            if let existingChild = current.children.first(where: { $0.name == name }) {
+                child = existingChild
+            } else {
+                let newChild = NodeConfig(name: name)
+                current.children.insert(newChild)
+                child = newChild
+                // Apply subtreeOptions to the child
+                child.subtreeOptions = current.subtreeOptions
+            }
+            return child
+        }
+        var isFirstComponent = true
+        for key in keyPath {
+            let key = key.replacingOccurrences(of: "\\.", with: ".")
+            // Extract the string part and array component part(s) from the key string
+            let components = extractArrayFormattedComponents(pathComponent: key)
+            
+            // Process string part of key
+            if let stringComponent = components.stringComponent {
+                current = findOrCreateChildNode(named: stringComponent)
+            }
+            
+            // Process array component parts if applicable
+            for arrayComponent in components.arrayComponents {
+                // 1. Check for general wildcard case
+                if arrayComponent == "[*]" {
+                    // this actually applies to the current node (since the named node is a collection by virtue of it having array components
+                    current.options[.wildcardMatch] = Config(isActive: true)
+                }
+                else {
+                    // 2. Extract valid indexes, and wildcard status
+                    // indexes represent the "named" child elements of arrays
+                    guard let indexResult = extractValidWildcardIndex(pathComponent: arrayComponent) else {
+                        return
+                    }
+                    let indexString = String(indexResult.index)
+                    current = findOrCreateChildNode(named: indexString)
+                    if indexResult.isWildcard {
+                        current.options[.wildcardMatch] = Config(isActive: true)
+                    }
+                }
+            }
+        }
+        
+        func propagateSubtreeOptions(for node: NodeConfig) {
+            for child in node.children {
+                child.subtreeOptions = node.subtreeOptions
+                propagateSubtreeOptions(for: child)
+            }
+        }
+
+        // Apply the node option to the final node
+        let key = pathConfig.optionKey
+        let config = Config(isActive: pathConfig.isActive)
+        let scope = pathConfig.scope
+        
+        if scope == .subtree {
+            current.subtreeOptions[key] = config
+            // Propagate this subtree option update to all children
+            propagateSubtreeOptions(for: current)
+        }
+        else {
+            current.options[key] = config
+        }
+    }
+    
+    
+    func asFinalNode() -> NodeConfig {
+        // should not modify since other function calls may still depend on children - return a new instance with the values set
+        return NodeConfig(name: nil, options: options, subtreeOptions: subtreeOptions)
+    }
+    
+    /// Extracts and returns a tuple with a valid index and a flag indicating whether it's a wildcard index from a single path component.
+    ///
+    /// This method considers a key that matches the array access format (ex: `[*123]` or `[123]`).
+    /// It identifies an index by optionally checking for the wildcard marker `*`.
+    ///
+    /// - Parameters:
+    ///   - pathComponent: A single path component which may contain a potential index with or without a wildcard marker.
+    ///   - file: The file from which the method is called, used for localized assertion failures.
+    ///   - line: The line from which the method is called, used for localized assertion failures.
+    ///
+    /// - Returns: A tuple containing an optional valid `Int` index and a boolean indicating whether it's a wildcard index.
+    ///   Returns nil if no valid index is found.
+    ///
+    /// - Note:
+    ///   Examples of conversions:
+    ///   - `[*123]` -> (123, true)
+    ///   - `[123]` -> (123, false)
+    ///   - `[*ab12]` causes a test failure since "ab12" is not a valid integer.
+    private func extractValidWildcardIndex(pathComponent: String, file: StaticString = #file, line: UInt = #line) -> (index: Int, isWildcard: Bool)? {
+        let arrayIndexValueRegex = #"^\[(.*?)\]$"#
+        guard let arrayIndexValue = getCapturedRegexGroups(text: pathComponent, regexPattern: arrayIndexValueRegex).first else {
+            XCTFail("TEST ERROR: unable to find valid index value from path component: \(pathComponent)")
+            return nil
+        }
+
+        let isWildcard = arrayIndexValue.starts(with: "*")
+        let indexString = isWildcard ? String(arrayIndexValue.dropFirst()) : arrayIndexValue
+
+        guard let validIndex = Int(indexString) else {
+            XCTFail("TEST ERROR: Index is not a valid Int: \(indexString)", file: file, line: line)
+            return nil
+        }
+
+        return (validIndex, isWildcard)
+    }
+    
+    /// Finds all matches of the `regexPattern` in the `text` and for each match, returns the original matched `String`
+    /// and its corresponding non-null capture groups.
+    ///
+    /// - Parameters:
+    ///   - text: The input `String` on which the regex matching is to be performed.
+    ///   - regexPattern: The regex pattern to be used for matching against the `text`.
+    ///
+    /// - Returns: An array of tuples, where each tuple consists of the original matched `String` and an array of its non-null capture groups. Returns `nil` if an invalid regex pattern is provided.
+    private func extractRegexCaptureGroups(text: String, regexPattern: String, file: StaticString = #file, line: UInt = #line) -> [(matchString: String, captureGroups: [String])]? {
+        do {
+            let regex = try NSRegularExpression(pattern: regexPattern)
+            let matches = regex.matches(in: text,
+                                        range: NSRange(text.startIndex..., in: text))
+            var matchResult: [(matchString: String, captureGroups: [String])] = []
+            for match in matches {
+                var rangeStrings: [String] = []
+                // [(matched string), (capture group 0), (capture group 1), etc.]
+                for rangeIndex in 0 ..< match.numberOfRanges {
+                    let rangeBounds = match.range(at: rangeIndex)
+                    guard let range = Range(rangeBounds, in: text) else {
+                        continue
+                    }
+                    rangeStrings.append(String(text[range]))
+                }
+                guard !rangeStrings.isEmpty else {
+                    continue
+                }
+                let matchString = rangeStrings.removeFirst()
+                matchResult.append((matchString: matchString, captureGroups: rangeStrings))
+            }
+            return matchResult
+        } catch let error {
+            XCTFail("TEST ERROR: Invalid regex: \(error.localizedDescription)", file: file, line: line)
+            return nil
+        }
+    }
+
+    /// Applies the provided regex pattern to the text and returns all the capture groups from the regex pattern
+    private func getCapturedRegexGroups(text: String, regexPattern: String, file: StaticString = #file, line: UInt = #line) -> [String] {
+
+        guard let captureGroups = extractRegexCaptureGroups(text: text, regexPattern: regexPattern, file: file, line: line)?.flatMap({ $0.captureGroups }) else {
+            return []
+        }
+
+        return captureGroups
+    }
+    
+    /// Extracts and returns the components of a given key path string.
+    ///
+    /// The method is designed to handle key paths in a specific style such as "key0\.key1.key2[1][2].key3", which represents
+    /// a nested structure in JSON objects. The method captures each group separated by the `.` character and treats
+    /// the sequence "\." as a part of the key itself (that is, it ignores "\." as a nesting indicator).
+    ///
+    /// For example, the input "key0\.key1.key2[1][2].key3" would result in the output: ["key0\.key1", "key2[1][2]", "key3"].
+    ///
+    /// - Parameter text: The input key path string that needs to be split into its components.
+    ///
+    /// - Returns: An array of strings representing the individual components of the key path. If the input `text` is empty,
+    /// a list containing an empty string is returned. If no components are found, an empty list is returned.
+    func getKeyPathComponents(from path: String?) -> [String] {
+        // Handle edge case where input is nil
+        guard let path = path else { return [] }
+        // Handle edge case where input is empty
+        if path.isEmpty { return [""] }
+
+        var segments: [String] = []
+        var startIndex = path.startIndex
+        var inEscapeSequence = false
+
+        // Iterate over each character in the input string with its index
+        for (index, char) in path.enumerated() {
+            let currentIndex = path.index(path.startIndex, offsetBy: index)
+
+            // If current character is a backslash and we're not already in an escape sequence
+            if char == "\\" {
+                inEscapeSequence = true
+            }
+            // If current character is a dot and we're not in an escape sequence
+            else if char == "." && !inEscapeSequence {
+                // Add the segment from the start index to current index (excluding the dot)
+                segments.append(String(path[startIndex..<currentIndex]))
+
+                // Update the start index for the next segment
+                startIndex = path.index(after: currentIndex)
+            }
+            // Any other character or if we're ending an escape sequence
+            else {
+                inEscapeSequence = false
+            }
+        }
+
+        // Add the remaining segment after the last dot (if any)
+        segments.append(String(path[startIndex...]))
+
+        // Handle edge case where input ends with a dot (but not an escaped dot)
+        if path.hasSuffix(".") && !path.hasSuffix("\\.") && segments.last != "" {
+            segments.append("")
+        }
+
+        return segments
+    }
+    
+    /// Extracts valid array format access components from a given path component and returns the separated components.
+    ///
+    /// Given `"key1[0][1]"`, the result is `["key1", "[0]", "[1]"]`.
+    /// Array format access can be escaped using a backslash character preceding an array bracket. Valid bracket escape sequences are cleaned so
+    /// that the final path component does not have the escape character.
+    /// For example: `"key1\[0\]"` results in the single path component `"key1[0]"`.
+    ///
+    /// - Parameter pathComponent: The path component to be split into separate components given valid array formatted components.
+    ///
+    /// - Returns: An array of `String` path components, where the original path component is divided into individual elements. Valid array format
+    ///  components in the original path are extracted as distinct elements, in order. If there are no array format components, the array contains only
+    ///  the original path component.
+    func extractArrayFormattedComponents(pathComponent: String) -> (stringComponent: String?, arrayComponents: [String]) {
+        // Handle edge case where input is empty
+        if pathComponent.isEmpty { return (stringComponent: "", arrayComponents: []) }
+        
+        var stringComponent: String = ""
+        var arrayComponents: [String] = []
+        var bracketCount = 0
+        var componentBuilder = ""
+        var nextCharIsBackslash = false
+        var lastArrayAccessEnd = pathComponent.endIndex // to track the end of the last valid array-style access
+
+        func isNextCharBackslash(i: String.Index) -> Bool {
+            if i == pathComponent.startIndex {
+                // There is no character before the startIndex.
+                return false
+            }
+
+            // Since we're iterating in reverse, the "next" character is before i
+            let previousIndex = pathComponent.index(before: i)
+            return pathComponent[previousIndex] == "\\"
+        }
+
+        outerLoop: for i in pathComponent.indices.reversed() {
+            switch pathComponent[i] {
+            case "]" where !isNextCharBackslash(i: i):
+                bracketCount += 1
+                componentBuilder.append("]")
+            case "[" where !isNextCharBackslash(i: i):
+                bracketCount -= 1
+                componentBuilder.append("[")
+                if bracketCount == 0 {
+                    arrayComponents.insert(String(componentBuilder.reversed()), at: 0)
+                    componentBuilder = ""
+                    lastArrayAccessEnd = i
+                }
+            case "\\":
+                if nextCharIsBackslash {
+                    nextCharIsBackslash = false
+                    continue outerLoop
+                } else {
+                    componentBuilder.append("\\")
+                }
+            default:
+                if bracketCount == 0 && i < lastArrayAccessEnd {
+                    stringComponent = String(pathComponent[pathComponent.startIndex...i])
+                    break outerLoop
+                }
+                componentBuilder.append(pathComponent[i])
+            }
+        }
+
+        // Add any remaining component that's not yet added
+        if !componentBuilder.isEmpty {
+            stringComponent = String(componentBuilder.reversed())
+        }
+        if !stringComponent.isEmpty {
+            stringComponent = stringComponent
+                                .replacingOccurrences(of: "\\[", with: "[")
+                                .replacingOccurrences(of: "\\]", with: "]")
+        }
+        if lastArrayAccessEnd == pathComponent.startIndex {
+            return (stringComponent: nil, arrayComponents: arrayComponents)
+        }
+        return (stringComponent: stringComponent, arrayComponents: arrayComponents)
+    }
+}
+
+extension NodeConfig: CustomStringConvertible {
+    public var description: String {
+        return describeNode(indentation: 0)
+    }
+
+    private func describeNode(indentation: Int) -> String {
+        var result = ""
+        let indentString = String(repeating: "  ", count: indentation) // Two spaces per indentation level
+
+        // Node name
+        result += "\(indentString)Name: \(name ?? "<Unnamed>")\n"
+
+        result += "\(indentString)FINAL options:\n"
+        
+        result += "\(indentString)Equal Count: \(collectionEqualCount)\n"
+        result += "\(indentString)Exact Match: \(primitiveExactMatch)\n"
+        result += "\(indentString)Wildcard   : \(wildcardMatch)\n"
+        
+        // Node options
+        // Accumulate options in a temporary string
+        let sortedOptions = options.sorted { $0.key < $1.key }
+        var optionsDescription = sortedOptions.map { (key, config) in
+            "\(indentString)  \(key): \(config)"
+        }.joined(separator: "\n")
+
+        // Append options to the result if there are any
+        if !optionsDescription.isEmpty {
+            result += "\(indentString)Options:\n" + optionsDescription + "\n"
+        }
+        
+        // Subtree
+        // Accumulate options in a temporary string
+        let sortedSubtreeOptions = subtreeOptions.sorted { $0.key < $1.key }
+        var subtreeOptionsDescription = sortedSubtreeOptions.map { (key, config) in
+            "\(indentString)  \(key): \(config)"
+        }.joined(separator: "\n")
+
+        // Append options to the result if there are any
+        if !subtreeOptionsDescription.isEmpty {
+            result += "\(indentString)Subtree options:\n" + subtreeOptionsDescription + "\n"
+        }
+        // Children nodes
+        if !children.isEmpty {
+            result += "\(indentString)Children:\n"
+            for child in children {
+                result += child.describeNode(indentation: indentation + 1)
+            }
+        }
+
+        return result
+    }
+}
+
+extension NodeConfig.OptionKey: Comparable {
+    public static func < (lhs: NodeConfig.OptionKey, rhs: NodeConfig.OptionKey) -> Bool {
+        // Implement comparison logic
+        // For enums without associated values, a simple approach is to compare their raw values
+        return lhs.rawValue < rhs.rawValue
+    }
+}
+
+public extension NodeConfig.NodeOption {
+    static func option(_ key: NodeConfig.OptionKey, active: Bool, scope: NodeConfig.Scope = .subtree) -> NodeConfig.NodeOption {
+        return .option(key, NodeConfig.Config(isActive: active), scope)
+    }
+}
+
+extension NodeConfig.Config: CustomStringConvertible {
+    public var description: String {
+        let isActiveDescription = (isActive ? "TRUE " : "FALSE").padding(toLength: 6, withPad: " ", startingAt: 0)
+        return "\(isActiveDescription)"
+    }
+}
+
+extension NodeConfig.OptionKey: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .wildcardMatch: return "Wildcard   "
+        case .collectionEqualCount: return "Equal Count"
+        case .primitiveExactMatch: return "Exact Match"
+        // Add cases for other options
+        }
+    }
+}
+
+extension NodeConfig.Scope: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .singleNode: return "Node"
+        case .subtree: return "Tree"
+        }
+    }
+}

--- a/Sources/RealNetworkService.swift
+++ b/Sources/RealNetworkService.swift
@@ -17,6 +17,10 @@ import XCTest
 /// Overriding NetworkService used for tests that require real outgoing network requests
 public class RealNetworkService: NetworkService {
     private let helper: NetworkRequestHelper = NetworkRequestHelper()
+    
+    public override init() {
+        super.init()
+    }
 
     public override func connectAsync(networkRequest: NetworkRequest, completionHandler: ((HttpConnection) -> Void)? = nil) {
         helper.recordSentNetworkRequest(networkRequest)

--- a/Sources/URL+Testable.swift
+++ b/Sources/URL+Testable.swift
@@ -12,7 +12,7 @@
 
 import Foundation
 
-extension URL {
+public extension URL {
     func queryParam(_ param: String) -> String? {
         guard let url = URLComponents(string: self.absoluteString) else { return nil }
         return url.queryItems?.first(where: { $0.name == param })?.value

--- a/Sources/XCTestCase+AnyCodableAsserts.swift
+++ b/Sources/XCTestCase+AnyCodableAsserts.swift
@@ -132,7 +132,10 @@ public extension AnyCodableAsserts where Self: XCTestCase {
     }
 
     func getAnyCodable(_ event: Event) -> AnyCodable? {
-        return AnyCodable(AnyCodable.from(dictionary: event.data))
+        guard let data = event.data else {
+            return AnyCodable(nil)
+        }
+        return AnyCodable(AnyCodable.from(dictionary: data))
     }
 
     func assertEqual(expected: AnyCodable?, actual: AnyCodable?, file: StaticString = #file, line: UInt = #line) {

--- a/Sources/XCTestCase+AnyCodableAsserts.swift
+++ b/Sources/XCTestCase+AnyCodableAsserts.swift
@@ -15,21 +15,13 @@ import AEPServices
 import Foundation
 import XCTest
 
-extension XCTestCase {
-    // MARK: - AnyCodable helpers
-
+public protocol AnyCodableAsserts {
     /// Gets the `AnyCodable` representation of a JSON string
-    public func getAnyCodable(_ jsonString: String) -> AnyCodable? {
-        return try? JSONDecoder().decode(AnyCodable.self, from: jsonString.data(using: .utf8)!)
-    }
-
+    func getAnyCodable(_ jsonString: String) -> AnyCodable?
+    
     /// Gets an event's data payload converted into `AnyCodable` format
-    public func getAnyCodable(_ event: Event) -> AnyCodable? {
-        return AnyCodable(AnyCodable.from(dictionary: event.data))
-    }
-
-    // MARK: - AnyCodable exact equivalence test assertion methods
-
+    func getAnyCodable(_ event: Event) -> AnyCodable?
+    
     /// Asserts exact equality between two `AnyCodable` instances.
     ///
     /// In the event of an assertion failure, this function provides a trace of the key path, which includes dictionary keys and array indexes,
@@ -40,11 +32,8 @@ extension XCTestCase {
     ///   - actual: The actual `AnyCodable` to compare.
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
-    public func assertEqual(expected: AnyCodable?, actual: AnyCodable?, file: StaticString = #file, line: UInt = #line) {
-        assertEqual(expected: expected, actual: actual, keyPath: [], file: file, line: line)
-    }
-
-    // MARK: - AnyCodable flexible validation test assertion methods
+    func assertEqual(expected: AnyCodable?, actual: AnyCodable?, file: StaticString, line: UInt)
+    
     /// Performs a flexible JSON comparison where only the key-value pairs from the expected JSON are required.
     /// By default, the function validates that both values are of the same type.
     ///
@@ -88,11 +77,8 @@ extension XCTestCase {
     ///   - exactMatchPaths: The key paths in the expected JSON that should use exact matching mode, where values require both the same type and literal value.
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
-    public func assertTypeMatch(expected: AnyCodable, actual: AnyCodable?, exactMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
-        let pathTree = generatePathTree(paths: exactMatchPaths, file: file, line: line)
-        assertFlexibleEqual(expected: expected, actual: actual, pathTree: pathTree, exactMatchMode: false, file: file, line: line)
-    }
-
+    func assertTypeMatch(expected: AnyCodable, actual: AnyCodable?, exactMatchPaths: [String], file: StaticString, line: UInt)
+    
     /// Performs a flexible JSON comparison where only the key-value pairs from the expected JSON are required.
     /// By default, the function uses exact match mode, validating that both values are of the same type
     /// and have the same literal value.
@@ -137,11 +123,32 @@ extension XCTestCase {
     ///   - typeMatchPaths: The key paths in the expected JSON that should use type matching mode, where values require only the same type (and are non-nil if the expected value is not nil).
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
-    public func assertExactMatch(expected: AnyCodable, actual: AnyCodable?, typeMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
+    func assertExactMatch(expected: AnyCodable, actual: AnyCodable?, typeMatchPaths: [String], file: StaticString, line: UInt)
+}
+
+public extension AnyCodableAsserts where Self: XCTestCase {
+    func getAnyCodable(_ jsonString: String) -> AnyCodable? {
+        return try? JSONDecoder().decode(AnyCodable.self, from: jsonString.data(using: .utf8)!)
+    }
+
+    func getAnyCodable(_ event: Event) -> AnyCodable? {
+        return AnyCodable(AnyCodable.from(dictionary: event.data))
+    }
+
+    func assertEqual(expected: AnyCodable?, actual: AnyCodable?, file: StaticString = #file, line: UInt = #line) {
+        XCTAssertEqual(expected, actual, file: file, line: line)
+    }
+
+    func assertTypeMatch(expected: AnyCodable, actual: AnyCodable?, exactMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
+        let pathTree = generatePathTree(paths: exactMatchPaths, file: file, line: line)
+        assertFlexibleEqual(expected: expected, actual: actual, pathTree: pathTree, exactMatchMode: false, file: file, line: line)
+    }
+
+    func assertExactMatch(expected: AnyCodable, actual: AnyCodable?, typeMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
         let pathTree = generatePathTree(paths: typeMatchPaths, file: file, line: line)
         assertFlexibleEqual(expected: expected, actual: actual, pathTree: pathTree, exactMatchMode: true, file: file, line: line)
     }
-
+    
     // MARK: - AnyCodable exact equivalence helpers
     /// Compares the given `expected` and `actual` values for exact equality. If they are not equal and an assertion fails,
     /// a test failure occurs.

--- a/Sources/XCTestCase+AnyCodableAsserts.swift
+++ b/Sources/XCTestCase+AnyCodableAsserts.swift
@@ -21,6 +21,9 @@ public protocol AnyCodableAsserts {
 
     /// Gets an event's data payload converted into `AnyCodable` format
     func getAnyCodable(_ event: Event) -> AnyCodable?
+    
+    /// Converts a network request's connect payload into `AnyCodable` format.
+    func getAnyCodable(_ networkRequest: NetworkRequest) -> AnyCodable?
 
     /// Asserts exact equality between two `AnyCodable` instances.
     ///
@@ -77,7 +80,8 @@ public protocol AnyCodableAsserts {
     ///   - exactMatchPaths: The key paths in the expected JSON that should use exact matching mode, where values require both the same type and literal value.
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
-    func assertTypeMatch(expected: AnyCodable, actual: AnyCodable?, exactMatchPaths: [String], file: StaticString, line: UInt)
+    func assertTypeMatch(expected: AnyCodable, actual: AnyCodable?, pathOptions: [MultiPathConfig], file: StaticString, line: UInt)
+    func assertTypeMatch(expected: AnyCodable, actual: AnyCodable?, pathOptions: MultiPathConfig..., file: StaticString, line: UInt)
 
     /// Performs a flexible JSON comparison where only the key-value pairs from the expected JSON are required.
     /// By default, the function uses exact match mode, validating that both values are of the same type
@@ -123,7 +127,8 @@ public protocol AnyCodableAsserts {
     ///   - typeMatchPaths: The key paths in the expected JSON that should use type matching mode, where values require only the same type (and are non-nil if the expected value is not nil).
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
-    func assertExactMatch(expected: AnyCodable, actual: AnyCodable?, typeMatchPaths: [String], file: StaticString, line: UInt)
+    func assertExactMatch(expected: AnyCodable, actual: AnyCodable?, pathOptions: [MultiPathConfig], file: StaticString, line: UInt)
+    func assertExactMatch(expected: AnyCodable, actual: AnyCodable?, pathOptions: MultiPathConfig..., file: StaticString, line: UInt)
 }
 
 public extension AnyCodableAsserts where Self: XCTestCase {
@@ -134,21 +139,45 @@ public extension AnyCodableAsserts where Self: XCTestCase {
     func getAnyCodable(_ event: Event) -> AnyCodable? {
         return AnyCodable(AnyCodable.from(dictionary: event.data))
     }
+    
+    func getAnyCodable(_ networkRequest: NetworkRequest) -> AnyCodable? {
+        guard let payloadAsDictionary = try? JSONSerialization.jsonObject(with: networkRequest.connectPayload, options: []) as? [String: Any] else {
+            return nil
+        }
+        return AnyCodable(AnyCodable.from(dictionary: payloadAsDictionary))
+    }
 
     func assertEqual(expected: AnyCodable?, actual: AnyCodable?, file: StaticString = #file, line: UInt = #line) {
         assertEqual(expected: expected, actual: actual, keyPath: [], file: file, line: line)
     }
 
-    func assertTypeMatch(expected: AnyCodable, actual: AnyCodable?, exactMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
-        let pathTree = generatePathTree(paths: exactMatchPaths, file: file, line: line)
-        assertFlexibleEqual(expected: expected, actual: actual, pathTree: pathTree, exactMatchMode: false, file: file, line: line)
+    func assertTypeMatch(expected: AnyCodable, actual: AnyCodable?, pathOptions: [MultiPathConfig] = [], file: StaticString = #file, line: UInt = #line) {
+        let treeDefaults: [MultiPathConfig] = [
+            WildcardMatch(paths: nil, isActive: false),
+            CollectionEqualCount(paths: nil, isActive: false),
+            ValueTypeMatch(paths: nil)]
+        
+        let nodeTree = generateNodeTree(pathOptions: pathOptions, treeDefaults: treeDefaults, file: file, line: line)
+        assertFlexibleEqual(expected: expected, actual: actual, nodeTree: nodeTree, file: file, line: line)
+    }
+    
+    func assertTypeMatch(expected: AnyCodable, actual: AnyCodable?, pathOptions: MultiPathConfig..., file: StaticString = #file, line: UInt = #line) {
+        assertTypeMatch(expected: expected, actual: actual, pathOptions: pathOptions, file: file, line: line)
     }
 
-    func assertExactMatch(expected: AnyCodable, actual: AnyCodable?, typeMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {
-        let pathTree = generatePathTree(paths: typeMatchPaths, file: file, line: line)
-        assertFlexibleEqual(expected: expected, actual: actual, pathTree: pathTree, exactMatchMode: true, file: file, line: line)
+    func assertExactMatch(expected: AnyCodable, actual: AnyCodable?, pathOptions: [MultiPathConfig] = [], file: StaticString = #file, line: UInt = #line) {
+        let treeDefaults: [MultiPathConfig] = [
+            WildcardMatch(paths: nil, isActive: false),
+            CollectionEqualCount(paths: nil, isActive: false),
+            ValueExactMatch(paths: nil)]
+        
+        let nodeTree = generateNodeTree(pathOptions: pathOptions, treeDefaults: treeDefaults, file: file, line: line)
+        assertFlexibleEqual(expected: expected, actual: actual, nodeTree: nodeTree, file: file, line: line)
     }
 
+    func assertExactMatch(expected: AnyCodable, actual: AnyCodable?, pathOptions: MultiPathConfig..., file: StaticString = #file, line: UInt = #line) {
+        assertExactMatch(expected: expected, actual: actual, pathOptions: pathOptions, file: file, line: line)
+    }
     // MARK: - AnyCodable exact equivalence helpers
     /// Compares the given `expected` and `actual` values for exact equality. If they are not equal and an assertion fails,
     /// a test failure occurs.
@@ -306,26 +335,25 @@ public extension AnyCodableAsserts where Self: XCTestCase {
     /// Performs a flexible comparison between the given `expected` and `actual` values, optionally using exact match
     /// or value type match modes. In case of a mismatch and if `shouldAssert` is `true`, a test failure occurs.
     ///
-    /// It allows for customized matching behavior through the `pathTree` and `exactMatchMode` parameters.
+    /// It allows for customized matching behavior through the `exactMatchPathTree` and `exactMatchMode` parameters.
     ///
     /// - Parameters:
     ///   - expected: The expected value to compare.
     ///   - actual: The actual value to compare.
     ///   - keyPath: A list of keys or array indexes representing the path to the current value being compared. Defaults to an empty list.
-    ///   - pathTree: A map representing specific paths within the JSON structure that should be compared using the alternate mode.
+    ///   - exactMatchPathTree: A map representing specific paths within the JSON structure that should be compared using the alternate mode.
     ///   - exactMatchMode: If `true`, performs an exact match comparison; otherwise, uses value type matching.
     ///   - shouldAssert: Indicates if an assertion error should be thrown if `expected` and `actual` are not equal. Defaults to `true`.
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
     ///
-    /// - Returns: `true` if `expected` and `actual` are equal based on the matching mode and the `pathTree`, otherwise returns `false`.
+    /// - Returns: `true` if `expected` and `actual` are equal based on the matching mode and the `exactMatchPathTree`, otherwise returns `false`.
     @discardableResult
     private func assertFlexibleEqual(
         expected: AnyCodable?,
         actual: AnyCodable?,
         keyPath: [Any] = [],
-        pathTree: [String: Any]?,
-        exactMatchMode: Bool,
+        nodeTree: NodeConfig,
         shouldAssert: Bool = true,
         file: StaticString = #file,
         line: UInt = #line) -> Bool {
@@ -355,7 +383,7 @@ public extension AnyCodableAsserts where Self: XCTestCase {
         case let (expected, actual) where (expected.value is Int && actual.value is Int):
             fallthrough
         case let (expected, actual) where (expected.value is Double && actual.value is Double):
-            if exactMatchMode {
+            if nodeTree.primitiveExactMatch.isActive {
                 if shouldAssert {
                     XCTAssertEqual(expected, actual, "Key path: \(keyPathAsString(keyPath))", file: file, line: line)
                 }
@@ -369,8 +397,7 @@ public extension AnyCodableAsserts where Self: XCTestCase {
                 expected: expected.value as? [String: AnyCodable],
                 actual: actual.value as? [String: AnyCodable],
                 keyPath: keyPath,
-                pathTree: pathTree,
-                exactMatchMode: exactMatchMode,
+                nodeTree: nodeTree,
                 shouldAssert: shouldAssert,
                 file: file,
                 line: line)
@@ -379,8 +406,7 @@ public extension AnyCodableAsserts where Self: XCTestCase {
                 expected: expected.value as? [AnyCodable],
                 actual: actual.value as? [AnyCodable],
                 keyPath: keyPath,
-                pathTree: pathTree,
-                exactMatchMode: exactMatchMode,
+                nodeTree: nodeTree,
                 shouldAssert: shouldAssert,
                 file: file,
                 line: line)
@@ -389,8 +415,7 @@ public extension AnyCodableAsserts where Self: XCTestCase {
                 expected: AnyCodable.from(array: expected.value as? [Any?]),
                 actual: AnyCodable.from(array: actual.value as? [Any?]),
                 keyPath: keyPath,
-                pathTree: pathTree,
-                exactMatchMode: exactMatchMode,
+                nodeTree: nodeTree,
                 shouldAssert: shouldAssert,
                 file: file,
                 line: line)
@@ -399,8 +424,7 @@ public extension AnyCodableAsserts where Self: XCTestCase {
                 expected: AnyCodable.from(dictionary: expected.value as? [String: Any?]),
                 actual: AnyCodable.from(dictionary: actual.value as? [String: Any?]),
                 keyPath: keyPath,
-                pathTree: pathTree,
-                exactMatchMode: exactMatchMode,
+                nodeTree: nodeTree,
                 shouldAssert: shouldAssert,
                 file: file,
                 line: line)
@@ -423,28 +447,28 @@ public extension AnyCodableAsserts where Self: XCTestCase {
     /// Performs a flexible comparison between the given `expected` and `actual` arrays of `AnyCodable`, optionally using exact match
     /// or value type match modes. In case of a mismatch and if `shouldAssert` is `true`, a test failure occurs.
     ///
-    /// It allows for customized matching behavior through the `pathTree` and `exactMatchMode` parameters.
+    /// It allows for customized matching behavior through the `exactMatchPathTree` and `exactMatchMode` parameters.
     ///
     /// - Parameters:
     ///   - expected: The expected array of `AnyCodable` to compare.
     ///   - actual: The actual array of `AnyCodable` to compare.
     ///   - keyPath: A list of keys or array indexes representing the path to the current value being compared.
-    ///   - pathTree: A map representing specific paths within the JSON structure that should be compared using the alternate mode.
+    ///   - exactMatchPathTree: A map representing specific paths within the JSON structure that should be compared using the alternate mode.
     ///   - exactMatchMode: If `true`, performs an exact match comparison; otherwise, uses value type matching.
     ///   - shouldAssert: Indicates if an assertion error should be thrown if `expected` and `actual` are not equal.
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
     ///
-    /// - Returns: `true` if `expected` and `actual` are equal based on the matching mode and the `pathTree`, otherwise returns `false`.
+    /// - Returns: `true` if `expected` and `actual` are equal based on the matching mode and the `exactMatchPathTree`, otherwise returns `false`.
     private func assertFlexibleEqual(
         expected: [AnyCodable]?,
         actual: [AnyCodable]?,
         keyPath: [Any],
-        pathTree: [String: Any]?,
-        exactMatchMode: Bool,
+        nodeTree: NodeConfig,
         shouldAssert: Bool = true,
         file: StaticString = #file,
-        line: UInt = #line) -> Bool {
+        line: UInt = #line) -> Bool 
+    {
         if expected == nil {
             return true
         }
@@ -462,10 +486,10 @@ public extension AnyCodableAsserts where Self: XCTestCase {
             }
             return false
         }
-        if expected.count > actual.count {
+        if nodeTree.collectionEqualCount.isActive ? (expected.count != actual.count) : (expected.count > actual.count) {
             if shouldAssert {
                 XCTFail(#"""
-                    Expected JSON has more elements than Actual JSON. Impossible for Actual to fulfill Expected requirements.
+                    Expected JSON \#(nodeTree.collectionEqualCount.isActive ? "count does not match" : "has more elements than") Actual JSON.
 
                     Expected count: \#(expected.count)
                     Actual count: \#(actual.count)
@@ -479,72 +503,70 @@ public extension AnyCodableAsserts where Self: XCTestCase {
             }
             return false
         }
-        var actualIndexes = Set(0..<actual.count)
-        var expectedIndexes = Set(0..<expected.count)
-        var wildcardIndexes: Set<Int>
-
-        // Collect all the keys from `pathTree` that either:
-        // 1. Mark the path end (where the value is a `String`), or
-        // 2. Contain the asterisk (*) character.
-        let pathEndKeys = pathTree?.filter { key, value in
-            value is String || key.contains("*")
-        }.keys.map({$0}) ?? []
-
-        // If general wildcard is present, it supersedes other paths
-        if pathEndKeys.contains("[*]") {
-            wildcardIndexes = Set(0..<expected.count)
-            expectedIndexes.removeAll()
-        } else {
-            let validWildcards = extractValidWildcardIndexes(pathEndKeys: pathEndKeys, file: file, line: line)
-            // Discard wildcard indexes that are out of bounds of the available expected indexes
-            let inBoundWildcards = expectedIndexes.intersection(validWildcards)
-            wildcardIndexes = inBoundWildcards
-            // Remove all wildcard indexes from the valid expected indexes, so assertions are not performed twice
-            expectedIndexes.subtract(wildcardIndexes)
+        
+        // get the set of all expected indexes
+        // resolve the effective option for wildcard matching
+        func resolveWildcardOption(for node: NodeConfig?, inArray arrayNodeConfig: NodeConfig) -> NodeConfig.Config {
+            // Check node's node-specific option
+            if let nodeOption = node?.options[.wildcardMatch] {
+                return nodeOption
+            }
+            // Check array's node-specific option
+            if let arrayOption = arrayNodeConfig.options[.wildcardMatch] {
+                return arrayOption
+            }
+            // Check node's subtree option, falling back to array node's default subtree config
+            return node?.wildcardMatch ?? arrayNodeConfig.wildcardMatch
         }
-
+        
+        // assert on non-wildcard ones first (both non-specified and specified)
+        // assert on wildcard ones
+        
+        var expectedIndexes = (0..<expected.count).reduce(into: [String: NodeConfig.Config]()) { result, index in
+            let indexString = String(index)
+            result[indexString] = NodeConfig.resolveOption(.wildcardMatch, for: nodeTree.getChild(named: indexString), parent: nodeTree)
+        }
+        let wildcardIndexes = expectedIndexes.filter({ $0.value.isActive })
+        wildcardIndexes.forEach { key, _ in
+            expectedIndexes.removeValue(forKey: key)
+        }
+        
+        var availableWildcardActualIndexes = Set((0..<actual.count).map({ String($0) })).subtracting(expectedIndexes.keys)
+        
         var finalResult = true
-
-        for index in expectedIndexes {
-            let pathTreeValue = pathTree?["[\(index)]"]
-            let isPathEnd = pathTreeValue is String
-
+        // Validate non-wildcard expected side indexes first, as these don't have
+        // position flexibility
+        for (index, config) in expectedIndexes {
+            let intIndex = Int(index)!
             finalResult = assertFlexibleEqual(
-                expected: expected[index],
-                actual: actual[index],
-                keyPath: keyPath + [index],
-                pathTree: pathTreeValue as? [String: Any],
-                exactMatchMode: isPathEnd != exactMatchMode,
+                expected: expected[intIndex],
+                actual: actual[intIndex],
+                keyPath: keyPath + [intIndex],
+                nodeTree: nodeTree.getChild(named: index) ?? nodeTree.asFinalNode(),
                 shouldAssert: shouldAssert,
                 file: file, line: line) && finalResult
-            actualIndexes.remove(index)
         }
+        
+        for (index, config) in wildcardIndexes {
+            let intIndex = Int(index)!
 
-        for index in wildcardIndexes {
-            let pathTreeValue = pathTree?["[*]"]
-                ?? pathTree?["[*\(index)]"]
-                ?? pathTree?["[\(index)*]"]
-
-            let isPathEnd = pathTreeValue is String
-
-            guard let actualIndex = actualIndexes.first(where: {
+            guard let actualIndex = availableWildcardActualIndexes.first(where: {
                 assertFlexibleEqual(
-                    expected: expected[index],
-                    actual: actual[$0],
-                    keyPath: keyPath + [index],
-                    pathTree: pathTreeValue as? [String: Any],
-                    exactMatchMode: isPathEnd != exactMatchMode,
+                    expected: expected[intIndex],
+                    actual: actual[Int($0)!],
+                    keyPath: keyPath + [intIndex],
+                    nodeTree: nodeTree.getChild(named: index) ?? nodeTree.asFinalNode(),
                     shouldAssert: false)
             }) else {
                 if shouldAssert {
                     XCTFail(#"""
-                        Wildcard \#((isPathEnd ? !exactMatchMode : exactMatchMode) ? "exact" : "type") match found no matches on Actual side satisfying the Expected requirement.
+                        Wildcard \#(NodeConfig.resolveOption(.primitiveExactMatch, for: nodeTree.getChild(named: index), parent: nodeTree).isActive ? "exact" : "type") match found no matches on Actual side satisfying the Expected requirement.
 
-                        Requirement: \#(String(describing: pathTreeValue))
+                        Requirement: \#(nodeTree)
 
-                        Expected: \#(expected[index])
+                        Expected: \#(expected[intIndex])
 
-                        Actual (remaining unmatched elements): \#(actualIndexes.map({ actual[$0] }))
+                        Actual (remaining unmatched elements): \#(availableWildcardActualIndexes.map({ actual[Int($0)!] }))
 
                         Key path: \#(keyPathAsString(keyPath))
                         """#, file: file, line: line)
@@ -552,36 +574,37 @@ public extension AnyCodableAsserts where Self: XCTestCase {
                 finalResult = false
                 break
             }
-            actualIndexes.remove(actualIndex)
+            availableWildcardActualIndexes.remove(actualIndex)
         }
+        
         return finalResult
     }
 
     /// Performs a flexible comparison between the given `expected` and `actual` dictionaries, optionally using exact match
     /// or value type match modes. In case of a mismatch and if `shouldAssert` is `true`, a test failure occurs.
     ///
-    /// It allows for customized matching behavior through the `pathTree` and `exactMatchMode` parameters.
+    /// It allows for customized matching behavior through the `exactMatchPathTree` and `exactMatchMode` parameters.
     ///
     /// - Parameters:
     ///   - expected: The expected dictionary of `AnyCodable` to compare.
     ///   - actual: The actual dictionary of `AnyCodable` to compare.
     ///   - keyPath: A list of keys or array indexes representing the path to the current value being compared.
-    ///   - pathTree: A map representing specific paths within the JSON structure that should be compared using the alternate mode.
+    ///   - exactMatchPathTree: A map representing specific paths within the JSON structure that should be compared using the alternate mode.
     ///   - exactMatchMode: If `true`, performs an exact match comparison; otherwise, uses value type matching.
     ///   - shouldAssert: Indicates if an assertion error should be thrown if `expected` and `actual` are not equal.
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
     ///
-    /// - Returns: `true` if `expected` and `actual` are equal based on the matching mode and the `pathTree`, otherwise returns `false`.
+    /// - Returns: `true` if `expected` and `actual` are equal based on the matching mode and the `exactMatchPathTree`, otherwise returns `false`.
     private func assertFlexibleEqual(
         expected: [String: AnyCodable]?,
         actual: [String: AnyCodable]?,
         keyPath: [Any],
-        pathTree: [String: Any]?,
-        exactMatchMode: Bool,
+        nodeTree: NodeConfig,
         shouldAssert: Bool = true,
         file: StaticString = #file,
-        line: UInt = #line) -> Bool {
+        line: UInt = #line) -> Bool 
+    {
         if expected == nil {
             return true
         }
@@ -599,10 +622,10 @@ public extension AnyCodableAsserts where Self: XCTestCase {
             }
             return false
         }
-        if expected.count > actual.count {
+        if nodeTree.collectionEqualCount.isActive ? (expected.count != actual.count) : (expected.count > actual.count) {
             if shouldAssert {
                 XCTFail(#"""
-                    Expected JSON has more elements than Actual JSON.
+                    Expected JSON \#(nodeTree.collectionEqualCount.isActive ? "count does not match" : "has more elements than") Actual JSON.
 
                     Expected count: \#(expected.count)
                     Actual count: \#(actual.count)
@@ -618,15 +641,11 @@ public extension AnyCodableAsserts where Self: XCTestCase {
         }
         var finalResult = true
         for (key, value) in expected {
-            let pathTreeValue = pathTree?[key]
-            let isPathEnd = pathTreeValue is String
-
             finalResult = assertFlexibleEqual(
                 expected: value,
                 actual: actual[key],
                 keyPath: keyPath + [key],
-                pathTree: pathTreeValue as? [String: Any],
-                exactMatchMode: isPathEnd != exactMatchMode,
+                nodeTree: nodeTree.getChild(named: key) ?? nodeTree.asFinalNode(),
                 shouldAssert: shouldAssert,
                 file: file,
                 line: line)
@@ -636,282 +655,6 @@ public extension AnyCodableAsserts where Self: XCTestCase {
     }
 
     // MARK: - Test setup and output helpers
-
-    /// Extracts and returns a set of valid wildcard indexes.
-    ///
-    /// This method only considers keys that match the array access format (ex: `[*123]`).
-    /// It identifies wildcard indexes by:
-    /// 1. Filtering out index values that don't have the wildcard marker `*`.
-    /// 2. Strictly validating the following, and emitting a test failure if any check fails:
-    ///   i. Wildcard character must be placed on the left of the index value (that is, as the leftmost character in the array brackets).
-    ///   ii. The index value must be parsable as a valid `Int` once the wildcard character is removed.
-    ///
-    /// - Parameters:
-    ///   - pathEndKeys: An array of end keys which may contain potential wildcard indexes.
-    ///   - file: The file from which the method is called, used for localized assertion failures.
-    ///   - line: The line from which the method is called, used for localized assertion failures.
-    ///
-    /// - Returns: A set of valid wildcard `Int` indexes.
-    ///
-    /// - Note:
-    ///   Examples of conversions:
-    ///   - `[*123]` -> `123`
-    ///   - `[*ab12]` causes a test failure since "ab12" is not a valid integer.
-    ///   - `[0*]` causes a test failure since the wildcard character `*` is not the leftmost character.
-    private func extractValidWildcardIndexes(pathEndKeys: [String], file: StaticString = #file, line: UInt = #line) -> Set<Int> {
-        let arrayIndexValueRegex = #"^\[(.*?)\]$"#
-        let arrayIndexValues = Set(pathEndKeys
-                                    .flatMap { getCapturedRegexGroups(text: $0, regexPattern: arrayIndexValueRegex) })
-
-        let potentialWildcardIndexes = arrayIndexValues
-            .filter { $0.contains("*") }
-
-        var result: Set<Int> = []
-        for potentialWildcardIndex in potentialWildcardIndexes {
-            if potentialWildcardIndex.first != "*" {
-                XCTFail("TEST ERROR: wildcard indexes must have a single `*` character to the left of the index (ex: [*0])", file: file, line: line)
-                continue
-            }
-            let wildcardIndexString = potentialWildcardIndex.dropFirst()
-            guard let validWildcardIndex = Int(wildcardIndexString) else {
-                XCTFail("TEST ERROR: wildcard index is not a valid Int: \(wildcardIndexString)", file: file, line: line)
-                continue
-            }
-            result.insert(validWildcardIndex)
-        }
-        return result
-    }
-
-    /// Finds all matches of the `regexPattern` in the `text` and for each match, returns the original matched `String`
-    /// and its corresponding non-null capture groups.
-    ///
-    /// - Parameters:
-    ///   - text: The input `String` on which the regex matching is to be performed.
-    ///   - regexPattern: The regex pattern to be used for matching against the `text`.
-    ///
-    /// - Returns: An array of tuples, where each tuple consists of the original matched `String` and an array of its non-null capture groups. Returns `nil` if an invalid regex pattern is provided.
-    private func extractRegexCaptureGroups(text: String, regexPattern: String, file: StaticString = #file, line: UInt = #line) -> [(matchString: String, captureGroups: [String])]? {
-        do {
-            let regex = try NSRegularExpression(pattern: regexPattern)
-            let matches = regex.matches(in: text,
-                                        range: NSRange(text.startIndex..., in: text))
-            var matchResult: [(matchString: String, captureGroups: [String])] = []
-            for match in matches {
-                var rangeStrings: [String] = []
-                // [(matched string), (capture group 0), (capture group 1), etc.]
-                for rangeIndex in 0 ..< match.numberOfRanges {
-                    let rangeBounds = match.range(at: rangeIndex)
-                    guard let range = Range(rangeBounds, in: text) else {
-                        continue
-                    }
-                    rangeStrings.append(String(text[range]))
-                }
-                guard !rangeStrings.isEmpty else {
-                    continue
-                }
-                let matchString = rangeStrings.removeFirst()
-                matchResult.append((matchString: matchString, captureGroups: rangeStrings))
-            }
-            return matchResult
-        } catch let error {
-            XCTFail("TEST ERROR: Invalid regex: \(error.localizedDescription)", file: file, line: line)
-            return nil
-        }
-    }
-
-    /// Applies the provided regex pattern to the text and returns all the capture groups from the regex pattern
-    private func getCapturedRegexGroups(text: String, regexPattern: String, file: StaticString = #file, line: UInt = #line) -> [String] {
-
-        guard let captureGroups = extractRegexCaptureGroups(text: text, regexPattern: regexPattern, file: file, line: line)?.flatMap({ $0.captureGroups }) else {
-            return []
-        }
-
-        return captureGroups
-    }
-
-    /// Extracts and returns the components of a given key path string.
-    ///
-    /// The method is designed to handle key paths in a specific style such as "key0\.key1.key2[1][2].key3", which represents
-    /// a nested structure in JSON objects. The method captures each group separated by the `.` character and treats
-    /// the sequence "\." as a part of the key itself (that is, it ignores "\." as a nesting indicator).
-    ///
-    /// For example, the input "key0\.key1.key2[1][2].key3" would result in the output: ["key0\.key1", "key2[1][2]", "key3"].
-    ///
-    /// - Parameter text: The input key path string that needs to be split into its components.
-    ///
-    /// - Returns: An array of strings representing the individual components of the key path. If the input `text` is empty,
-    /// a list containing an empty string is returned. If no components are found, an empty list is returned.
-    func getKeyPathComponents(text: String) -> [String] {
-        // Handle edge case where input is empty
-        if text.isEmpty { return [""] }
-
-        var segments: [String] = []
-        var startIndex = text.startIndex
-        var inEscapeSequence = false
-
-        // Iterate over each character in the input string with its index
-        for (index, char) in text.enumerated() {
-            let currentIndex = text.index(text.startIndex, offsetBy: index)
-
-            // If current character is a backslash and we're not already in an escape sequence
-            if char == "\\" {
-                inEscapeSequence = true
-            }
-            // If current character is a dot and we're not in an escape sequence
-            else if char == "." && !inEscapeSequence {
-                // Add the segment from the start index to current index (excluding the dot)
-                segments.append(String(text[startIndex..<currentIndex]))
-
-                // Update the start index for the next segment
-                startIndex = text.index(after: currentIndex)
-            }
-            // Any other character or if we're ending an escape sequence
-            else {
-                inEscapeSequence = false
-            }
-        }
-
-        // Add the remaining segment after the last dot (if any)
-        segments.append(String(text[startIndex...]))
-
-        // Handle edge case where input ends with a dot (but not an escaped dot)
-        if text.hasSuffix(".") && !text.hasSuffix("\\.") && segments.last != "" {
-            segments.append("")
-        }
-
-        return segments
-    }
-
-    /// Merges two constructed key path dictionaries, replacing `current` values with `new` ones, with the exception
-    /// of existing values that are String types, which mean that it is a final key path from a different path string
-    /// Merge order doesn't matter, the final result should always be the same
-    ///
-    /// Merges two given dictionaries, with the values from the `new` map overwriting those from the `current` map,
-    /// unless the value in the `current` map is a `String`, which means it is the end of an existing path.
-    ///
-    /// If both the `current` and `new` dictionary have a value which is itself a dictionary for the same key,
-    /// the function will recursively merge these nested dictionaries.
-    ///
-    /// - Parameters:
-    ///   - current: The original dictionary that will be merged into.
-    ///   - new: The dictionary containing new values that will overwrite or be added to the `current` dictionary.
-    ///
-    /// - Returns: The merged dictionary, which is the result of the `current` map after merging.
-
-    private func merge(current: [String: Any], new: [String: Any]) -> [String: Any] {
-        var current = current
-        for (key, newValue) in new {
-            let currentValue = current[key]
-            switch (currentValue, newValue) {
-            case let (currentValue as [String: Any], newValue as [String: Any]):
-                current[key] = merge(current: currentValue, new: newValue)
-            default:
-                if current[key] is String {
-                    continue
-                }
-                current[key] = newValue
-            }
-        }
-        return current
-    }
-
-    /// Constructs a nested dictionary structure based on the provided path, with the deepest nested key pointing to the given `pathString`.
-    ///
-    /// For instance, given a path of `["a", "b", "c"]` and a `pathString` of `"a.b.c"`, the resulting dictionary would be:
-    /// `{"a": {"b": {"c": "a.b.c"}}}`.
-    ///
-    /// - Parameters:
-    ///   - path: An array of strings representing the sequence of nested keys for the dictionary structure.
-    ///   - pathString: The `String` value that will be associated with the deepest nested key in the constructed dictionary.
-    ///
-    /// - Returns: A dictionary representing the nested structure constructed from the `path`, with the deepest nested key having the value `pathString`.
-    private func construct(path: [String], pathString: String) -> [String: Any] {
-        guard !path.isEmpty else {
-            return [:]
-        }
-        var path = path
-        let first = path.removeFirst()
-        let result: [String: Any]
-        if path.isEmpty {
-            result = [first: pathString]
-            return result
-        } else {
-
-            return [first: construct(path: path, pathString: pathString)]
-        }
-    }
-
-    /// Extracts valid array format access components from a given path component and returns the separated components.
-    ///
-    /// Given `"key1[0][1]"`, the result is `["key1", "[0]", "[1]"]`.
-    /// Array format access can be escaped using a backslash character preceding an array bracket. Valid bracket escape sequences are cleaned so
-    /// that the final path component does not have the escape character.
-    /// For example: `"key1\[0\]"` results in the single path component `"key1[0]"`.
-    ///
-    /// - Parameter pathComponent: The path component to be split into separate components given valid array formatted components.
-    ///
-    /// - Returns: An array of `String` path components, where the original path component is divided into individual elements. Valid array format
-    ///  components in the original path are extracted as distinct elements, in order. If there are no array format components, the array contains only
-    ///  the original path component.
-    func extractArrayFormattedComponents(pathComponent: String) -> [String] {
-        // Handle edge case where input is empty
-        if pathComponent.isEmpty { return [""] }
-
-        var components: [String] = []
-        var bracketCount = 0
-        var componentBuilder = ""
-        var nextCharIsBackslash = false
-        var lastArrayAccessEnd = pathComponent.endIndex // to track the end of the last valid array-style access
-
-        func isNextCharBackslash(i: String.Index) -> Bool {
-            if i == pathComponent.startIndex {
-                // There is no character before the startIndex.
-                return false
-            }
-
-            // Since we're iterating in reverse, the "next" character is before i
-            let previousIndex = pathComponent.index(before: i)
-            return pathComponent[previousIndex] == "\\"
-        }
-
-        outerLoop: for i in pathComponent.indices.reversed() {
-            switch pathComponent[i] {
-            case "]" where !isNextCharBackslash(i: i):
-                bracketCount += 1
-                componentBuilder.append("]")
-            case "[" where !isNextCharBackslash(i: i):
-                bracketCount -= 1
-                componentBuilder.append("[")
-                if bracketCount == 0 {
-                    components.insert(String(componentBuilder.reversed()), at: 0)
-                    componentBuilder = ""
-                    lastArrayAccessEnd = i
-                }
-            case "\\":
-                if nextCharIsBackslash {
-                    nextCharIsBackslash = false
-                    continue outerLoop
-                } else {
-                    componentBuilder.append("\\")
-                }
-            default:
-                if bracketCount == 0 && i < lastArrayAccessEnd {
-                    components.insert(String(pathComponent[pathComponent.startIndex...i]), at: 0)
-                    break outerLoop
-                }
-                componentBuilder.append(pathComponent[i])
-            }
-        }
-
-        // Add any remaining component that's not yet added
-        if !componentBuilder.isEmpty {
-            components.insert(String(componentBuilder.reversed()), at: 0)
-        }
-        if !components.isEmpty {
-            components[0] = components[0].replacingOccurrences(of: "\\[", with: "[").replacingOccurrences(of: "\\]", with: "]")
-        }
-        return components
-    }
 
     /// Generates a tree structure from an array of path `String`s.
     ///
@@ -924,26 +667,27 @@ public extension AnyCodableAsserts where Self: XCTestCase {
     ///
     /// - Returns: A tree-like dictionary structure representing the nested structure of the provided paths. Returns `nil` if the
     /// resulting tree is empty.
-    private func generatePathTree(paths: [String], file: StaticString = #file, line: UInt = #line) -> [String: Any]? {
-        var tree: [String: Any] = [:]
-
-        for path in paths {
-            var allPathComponents: [String] = []
-
-            // Break the path string into its component parts
-            let keyPathComponents = getKeyPathComponents(text: path)
-            for pathComponent in keyPathComponents {
-                let pathComponent = pathComponent.replacingOccurrences(of: "\\.", with: ".")
-
-                let components = extractArrayFormattedComponents(pathComponent: pathComponent)
-                allPathComponents.append(contentsOf: components)
-            }
-
-            let constructedTree = construct(path: allPathComponents, pathString: path)
-            tree = merge(current: tree, new: constructedTree)
-
+    private func generateNodeTree(pathOptions: [MultiPathConfig], treeDefaults: [MultiPathConfig], file: StaticString = #file, line: UInt = #line) -> NodeConfig {
+        // 1. creates the first node using the incoming defaults
+        // using the first node it passes the path to the node to create the child nodes and just loops through all the paths passing them
+        
+        // Root node doesn't have a name
+        // also has the responsibility of setting the defaults for the tree
+        // TODO: update the isActive defaults to be passed from the initial caller
+        var subtreeOptions: [NodeConfig.OptionKey: NodeConfig.Config] = [:]
+        for treeDefault in treeDefaults {
+            let key = treeDefault.optionKey
+            let config = NodeConfig.Config(isActive: treeDefault.isActive)
+            subtreeOptions[key] = config
         }
-        return tree.isEmpty ? nil : tree
+        
+        let rootNode = NodeConfig(name: nil, subtreeOptions: subtreeOptions)
+
+        for pathConfig in pathOptions {
+            rootNode.createOrUpdateNode(using: pathConfig)
+        }
+        
+        return rootNode
     }
 
     /// Converts a key path represented by an array of JSON object keys and array indexes into a human-readable `String` format.

--- a/Sources/XCTestCase+AnyCodableAsserts.swift
+++ b/Sources/XCTestCase+AnyCodableAsserts.swift
@@ -18,10 +18,10 @@ import XCTest
 public protocol AnyCodableAsserts {
     /// Gets the `AnyCodable` representation of a JSON string
     func getAnyCodable(_ jsonString: String) -> AnyCodable?
-    
+
     /// Gets an event's data payload converted into `AnyCodable` format
     func getAnyCodable(_ event: Event) -> AnyCodable?
-    
+
     /// Asserts exact equality between two `AnyCodable` instances.
     ///
     /// In the event of an assertion failure, this function provides a trace of the key path, which includes dictionary keys and array indexes,
@@ -33,7 +33,7 @@ public protocol AnyCodableAsserts {
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
     func assertEqual(expected: AnyCodable?, actual: AnyCodable?, file: StaticString, line: UInt)
-    
+
     /// Performs a flexible JSON comparison where only the key-value pairs from the expected JSON are required.
     /// By default, the function validates that both values are of the same type.
     ///
@@ -78,7 +78,7 @@ public protocol AnyCodableAsserts {
     ///   - file: The file from which the method is called, used for localized assertion failures.
     ///   - line: The line from which the method is called, used for localized assertion failures.
     func assertTypeMatch(expected: AnyCodable, actual: AnyCodable?, exactMatchPaths: [String], file: StaticString, line: UInt)
-    
+
     /// Performs a flexible JSON comparison where only the key-value pairs from the expected JSON are required.
     /// By default, the function uses exact match mode, validating that both values are of the same type
     /// and have the same literal value.
@@ -148,7 +148,7 @@ public extension AnyCodableAsserts where Self: XCTestCase {
         let pathTree = generatePathTree(paths: typeMatchPaths, file: file, line: line)
         assertFlexibleEqual(expected: expected, actual: actual, pathTree: pathTree, exactMatchMode: true, file: file, line: line)
     }
-    
+
     // MARK: - AnyCodable exact equivalence helpers
     /// Compares the given `expected` and `actual` values for exact equality. If they are not equal and an assertion fails,
     /// a test failure occurs.

--- a/Sources/XCTestCase+AnyCodableAsserts.swift
+++ b/Sources/XCTestCase+AnyCodableAsserts.swift
@@ -132,14 +132,11 @@ public extension AnyCodableAsserts where Self: XCTestCase {
     }
 
     func getAnyCodable(_ event: Event) -> AnyCodable? {
-        guard let data = event.data else {
-            return AnyCodable(nil)
-        }
-        return AnyCodable(AnyCodable.from(dictionary: data))
+        return AnyCodable(AnyCodable.from(dictionary: event.data))
     }
 
     func assertEqual(expected: AnyCodable?, actual: AnyCodable?, file: StaticString = #file, line: UInt = #line) {
-        XCTAssertEqual(expected, actual, file: file, line: line)
+        assertEqual(expected: expected, actual: actual, keyPath: [], file: file, line: line)
     }
 
     func assertTypeMatch(expected: AnyCodable, actual: AnyCodable?, exactMatchPaths: [String] = [], file: StaticString = #file, line: UInt = #line) {

--- a/Tests/UnitTests/AnyCodableAssertsParameterizedTests.swift
+++ b/Tests/UnitTests/AnyCodableAssertsParameterizedTests.swift
@@ -1,0 +1,433 @@
+//
+// Copyright 2023 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import AEPServices
+import AEPTestUtils
+import Foundation
+import XCTest
+
+class AnyCodableAssertsParameterizedTests: XCTestCase {
+    func testValueMatching() {
+        let rawCases: [(expected: Any, actual: Any)] = [
+            (expected: 1, actual: 1),
+            (expected: 5.0, actual: 5.0),
+            (expected: true, actual: true),
+            (expected: "a", actual: "a"),
+            (expected: "안녕하세요", actual: "안녕하세요")
+        ]
+        let testCases = rawCases.map { tuple in
+            return (expected: AnyCodable(tuple.expected), actual: AnyCodable(tuple.actual))
+        }
+        for (index, (expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should match basic values: [\(index)]: test with expected=\(expected), actual=\(actual)") { _ in
+                assertEqual(expected: expected, actual: actual)
+                assertExactMatch(expected: expected, actual: actual)
+                assertTypeMatch(expected: expected, actual: actual)
+            }
+        }
+    }
+
+    func testCollectionValueMatching() {
+        let rawCases: [(expected: String, actual: String)] = [
+            (expected: "[]", actual: "[]"), // Empty array
+            (expected: "[[[]]]", actual: "[[[]]]"), // Nested arrays
+            (expected: "{}", actual: "{}"), // Empty dictionary
+            (expected: #"{ "key1": 1 }"#, actual: #"{ "key1": 1 }"#), // Key value pair
+            (expected: #"{ "key1": { "key2": {} } }"#, actual: #"{ "key1": { "key2": {} } }"#), // Nested objects
+            (expected: #"{ "key1": null }"#, actual: #"{ "key1": null }"#) // `null` as value
+        ]
+        let testCases = rawCases.map { tuple in
+            return (expected: getAnyCodable(tuple.expected)!, actual: getAnyCodable(tuple.actual))
+        }
+        for (index, (expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should match basic collection values: [\(index)]: test with expected=\(expected), actual=\(actual)") { _ in
+                assertEqual(expected: expected, actual: actual)
+                assertExactMatch(expected: expected, actual: actual)
+                assertTypeMatch(expected: expected, actual: actual)
+            }
+        }
+    }
+
+    func testTypeMatching() {
+        let rawCases: [(expected: Any, actual: Any)] = [
+            (expected: 5, actual: 10), // Int
+            (expected: 5.0, actual: 10.0), // Double
+            (expected: true, actual: false), // Bool
+            (expected: "a", actual: "b"), // String
+            (expected: "안", actual: "안녕하세요") // Non-Latin String
+        ]
+        let testCases = rawCases.map { tuple in
+            return (expected: AnyCodable(tuple.expected), actual: AnyCodable(tuple.actual))
+        }
+        for (index, (expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should match only by type for values of the same type: [\(index)]: test with expected=\(expected), actual=\(actual)") { _ in
+                XCTExpectFailure("Validation should fail when asserting exact equality for different values of the same type") {
+                    assertExactMatch(expected: expected, actual: actual)
+                }
+                XCTExpectFailure("Validation should fail when asserting exact matches for different values of the same type") {
+                    assertExactMatch(expected: expected, actual: actual)
+                }
+                assertTypeMatch(expected: expected, actual: actual)
+            }
+        }
+    }
+
+    func testCollectionTypeMatching() {
+        let rawCases: [(expected: String, actual: String)] = [
+            (expected: #"{ "key1": 1 }"#, actual: #"{ "key1": 2 }"#),
+            (expected: #"{ "key1": { "key2": "a" } }"#, actual: #"{ "key1": { "key2": "b", "key3": 3 } }"#)
+        ]
+        let testCases = rawCases.map { tuple in
+            return (expected: getAnyCodable(tuple.expected)!, actual: getAnyCodable(tuple.actual))
+        }
+        for (index, (expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should match only by type for values of the same type: [\(index)]: test with expected=\(expected), actual=\(actual)") { _ in
+                XCTExpectFailure("Validation should fail when asserting exact equality for collections with different values or structures") {
+                    assertEqual(expected: expected, actual: actual)
+                }
+
+                XCTExpectFailure("Validation should fail when asserting exact matches for collections with different values or structures") {
+                    assertExactMatch(expected: expected, actual: actual)
+                }
+
+                assertTypeMatch(expected: expected, actual: actual)
+            }
+        }
+    }
+
+    func testFlexibleCollectionTypeMatching() {
+        let rawCases: [(expected: String, actual: String)] = [
+            (expected: #"[]"#, actual: #"[1]"#),
+            (expected: #"[1,2,3]"#, actual: #"[1,2,3,4]"#),
+            (expected: #"{}"#, actual: #"{ "k": "v" }"#),
+            (expected: #"{ "key1": 1, "key2": "a", "key3": 1.0, "key4": true }"#,
+             actual: #"{ "key1": 1, "key2": "a", "key3": 1.0, "key4": true, "key5": "extra" }"#)
+        ]
+        let testCases = rawCases.map { tuple in
+            return (expected: getAnyCodable(tuple.expected)!, actual: getAnyCodable(tuple.actual))
+        }
+        for (index, (expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should pass flexible matching when expected is a subset: [\(index)]: test with expected=\(expected), actual=\(actual)") { _ in
+                XCTExpectFailure("Validation should fail when asserting exact equality for collections where the actual has extra elements or keys") {
+                    assertEqual(expected: expected, actual: actual)
+                }
+                assertExactMatch(expected: expected, actual: actual)
+                assertTypeMatch(expected: expected, actual: actual)
+            }
+        }
+    }
+
+    func testFailure() {
+        // Some cases do a double validation, where they check for unintended type casting
+        // and the value type mismatch itself
+        let rawCases: [(expected: Any?, actual: Any?)] = [
+            (expected: 1, actual: 1.0), // [0]
+            (expected: 1, actual: "1"),
+            (expected: 1, actual: true),
+            (expected: 0, actual: false),
+            (expected: 1, actual: [:] as [String: Any]),
+            (expected: 1, actual: [] as [Any]), // [5]
+            (expected: 1, actual: nil),
+            (expected: 2.0, actual: 2),
+            (expected: 2.0, actual: "2.0"),
+            (expected: 1.0, actual: true),
+            (expected: 0.0, actual: false), // [10]
+            (expected: 1.0, actual: false),
+            (expected: 2.0, actual: [:] as [String: Any]),
+            (expected: 2.0, actual: [] as [Any]),
+            (expected: 2.0, actual: nil),
+            (expected: "1", actual: 1), // [15]
+            (expected: "2.0", actual: 2.0),
+            (expected: "true", actual: true),
+            (expected: "false", actual: false),
+            (expected: "{}", actual: [:] as [String: Any]),
+            (expected: "[]", actual: [] as [Any]), // [20]
+            (expected: "null", actual: nil),
+            (expected: "nil", actual: nil),
+            (expected: true, actual: 1),
+            (expected: true, actual: 1.0),
+            (expected: true, actual: "true"), // [25]
+            (expected: true, actual: [:] as [String: Any]),
+            (expected: true, actual: [] as [Any]),
+            (expected: true, actual: nil),
+            (expected: false, actual: 0),
+            (expected: false, actual: 0.0), // [30]
+            (expected: false, actual: 1.0),
+            (expected: false, actual: "false"),
+            (expected: false, actual: [:] as [String: Any]),
+            (expected: false, actual: [] as [Any]),
+            (expected: false, actual: nil), // [35]
+            (expected: [:] as [String: Any], actual: 1),
+            (expected: [:] as [String: Any], actual: 2.0),
+            (expected: [:] as [String: Any], actual: "{}"),
+            (expected: [:] as [String: Any], actual: true),
+            (expected: [:] as [String: Any], actual: [] as [Any]), // [40]
+            (expected: [:] as [String: Any], actual: nil),
+            (expected: ["key1": 1] as [String: Any], actual: ["key2": 1] as [String: Any]),
+            (expected: [] as [Any], actual: 1),
+            (expected: [] as [Any], actual: 2.0),
+            (expected: [] as [Any], actual: "[]"), // [45]
+            (expected: [] as [Any], actual: true),
+            (expected: [] as [Any], actual: [:] as [String: Any]),
+            (expected: [] as [Any], actual: nil)
+        ]
+        let testCases = rawCases.map { tuple in
+            return (expected: AnyCodable(tuple.expected), actual: AnyCodable(tuple.actual))
+        }
+        for (index, (expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should error when not matching: [\(index)]: test with expected=\(expected), actual=\(actual)") { _ in
+                XCTExpectFailure("Validation should fail when expected and actual have different types") {
+                    assertEqual(expected: expected, actual: actual)
+                }
+                XCTExpectFailure("Validation should fail when expected and actual have different types") {
+                    assertExactMatch(expected: expected, actual: actual)
+                }
+                XCTExpectFailure("Validation should fail when expected and actual have different types") {
+                    assertTypeMatch(expected: expected, actual: actual)
+                }
+            }
+        }
+    }
+
+    func testSpecialKey() {
+        let rawCases: [(expected: String, actual: String)] = [
+            (expected: #"{ "": 1 }"#, actual: #"{ "": 1 }"#), // Empty string
+            (expected: #"{ "\\": 1 }"#, actual: #"{ "\\": 1 }"#), // Backslash
+            (expected: #"{ "\\\\": 1 }"#, actual: #"{ "\\\\": 1 }"#), // Double backslash
+            (expected: #"{ ".": 1 }"#, actual: #"{ ".": 1 }"#), // Dot
+            (expected: #"{ "k.1.2.3": 1 }"#, actual: #"{ "k.1.2.3": 1 }"#), // Dot in key
+            (expected: #"{ "k.": 1 }"#, actual: #"{ "k.": 1 }"#), // Dot at the end of key
+            (expected: #"{ "\"": 1 }"#, actual: #"{ "\"": 1 }"#), // Escaped double quote
+            (expected: #"{ "'": 1 }"#, actual: #"{ "'": 1 }"#), // Single quote
+            (expected: #"{ "\\'": 1 }"#, actual: #"{ "\\'": 1 }"#), // Backslash before single quote
+            (expected: #"{ "key with space": 1 }"#, actual: #"{ "key with space": 1 }"#), // Space in key
+            (expected: #"{ "\n": 1 }"#, actual: #"{ "\n": 1 }"#), // Control character
+            (expected: #"{ "key \t \n newline": 1 }"#, actual: #"{ "key \t \n newline": 1 }"#), // Control characters in key
+            (expected: #"{ "안녕하세요": 1 }"#, actual: #"{ "안녕하세요": 1 }"#) // Non-Latin characters
+        ]
+        let testCases = rawCases.map { tuple in
+            print(tuple)
+            let expectedAnyCodable: AnyCodable? = getAnyCodable(tuple.expected)
+            let actualAnyCodable: AnyCodable? = getAnyCodable(tuple.actual)
+            return (expected: expectedAnyCodable!, actual: actualAnyCodable)
+        }
+        print("translated testCases: \(testCases)")
+        for (index, (expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should match special key JSONs: [\(index)]: test with expected=\(expected), actual=\(actual)") { _ in
+                assertEqual(expected: expected, actual: actual)
+                assertExactMatch(expected: expected, actual: actual)
+                assertTypeMatch(expected: expected, actual: actual)
+            }
+        }
+    }
+
+    func testAlternatePathValueDictionary() {
+        let rawCases: [(path: String, expected: Any?, actual: Any?, format: (Any?) -> String)] = [
+            (path: "key1", expected: 1, actual: 1, format: { #"{ "key1": \#($0!) }"# }),
+            (path: "key1", expected: 2.0, actual: 2.0, format: { #"{ "key1": \#($0!) }"# }),
+            (path: "key1", expected: "a", actual: "a", format: { #"{ "key1": "\#($0!)" }"# }),
+            (path: "key1", expected: true, actual: true, format: { #"{ "key1": \#($0!) }"# }),
+            (path: "key1", expected: "{}", actual: "{}", format: { #"{ "key1": \#($0!) }"# }),
+            (path: "key1", expected: "[]", actual: "[]", format: { #"{ "key1": \#($0!) }"# }),
+            (path: "key1", expected: nil, actual: nil, format: { #"{ "key1": \#($0 ?? "null") }"# })
+        ]
+        let testCases = rawCases.map { tuple in
+            let expectedAnyCodable: AnyCodable? = getAnyCodable(tuple.format(tuple.expected))
+            let actualAnyCodable: AnyCodable? = getAnyCodable(tuple.format(tuple.actual))
+            return (path: tuple.path, expected: expectedAnyCodable!, actual: actualAnyCodable)
+        }
+        for (index, (path, expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should not fail because of alternate path: [\(index)]: test with path=\(path), expected=\(expected), actual=\(actual)") { _ in
+                assertExactMatch(expected: expected, actual: actual, typeMatchPaths: [path])
+                assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: [path])
+            }
+        }
+    }
+
+    func testAlternatePathValueArray() {
+        let rawCases: [(path: String, expected: Any?, actual: Any?, format: (Any?) -> String)] = [
+            // Validating array format with specific index alternate mode path
+            (path: "[0]", expected: 1, actual: 1, format: { #"[\#($0!)]"# }),
+            (path: "[0]", expected: 2.0, actual: 2.0, format: { #"[\#($0!)]"# }),
+            (path: "[0]", expected: "a", actual: "a", format: { #"["\#($0!)"]"# }),
+            (path: "[0]", expected: true, actual: true, format: { #"[\#($0!)]"# }),
+            (path: "[0]", expected: "{}", actual: "{}", format: { #"[\#($0!)]"# }),
+            (path: "[0]", expected: "[]", actual: "[]", format: { #"[\#($0!)]"# }),
+            (path: "[0]", expected: nil, actual: nil, format: { #"[\#($0 ?? "null")]"# }),
+            // Validating array format with wildcard alternate mode path
+            (path: "[*]", expected: 1, actual: 1, format: { #"[\#($0!)]"# }),
+            (path: "[*]", expected: 2.0, actual: 2.0, format: { #"[\#($0!)]"# }),
+            (path: "[*]", expected: "a", actual: "a", format: { #"["\#($0!)"]"# }),
+            (path: "[*]", expected: true, actual: true, format: { #"[\#($0!)]"# }),
+            (path: "[*]", expected: "{}", actual: "{}", format: { #"[\#($0!)]"# }),
+            (path: "[*]", expected: "[]", actual: "[]", format: { #"[\#($0!)]"# }),
+            (path: "[*]", expected: nil, actual: nil, format: { #"[\#($0 ?? "null")]"# })
+        ]
+        let testCases = rawCases.map { tuple in
+            let expectedAnyCodable: AnyCodable? = getAnyCodable(tuple.format(tuple.expected))
+            let actualAnyCodable: AnyCodable? = getAnyCodable(tuple.format(tuple.actual))
+            return (path: tuple.path, expected: expectedAnyCodable!, actual: actualAnyCodable)
+        }
+        for (index, (path, expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should not fail because of alternate path: [\(index)]: test with path=\(path), expected=\(expected), actual=\(actual)") { _ in
+                assertExactMatch(expected: expected, actual: actual, typeMatchPaths: [path])
+                assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: [path])
+            }
+        }
+    }
+
+    func testAlternatePathTypeDictionary() {
+        let rawCases: [(path: String, expected: Any?, actual: Any?, format: (Any?) -> String)] = [
+            (path: "key1", expected: 1, actual: 2, format: { #"{ "key1": \#($0!) }"# }),
+            (path: "key1", expected: 1.0, actual: 2.0, format: { #"{ "key1": \#($0!) }"# }),
+            (path: "key1", expected: "a", actual: "b", format: { #"{ "key1": "\#($0!)" }"# }),
+            (path: "key1", expected: true, actual: false, format: { #"{ "key1": \#($0!) }"# })
+        ]
+        let testCases = rawCases.map { tuple in
+            let expectedAnyCodable: AnyCodable? = getAnyCodable(tuple.format(tuple.expected))
+            let actualAnyCodable: AnyCodable? = getAnyCodable(tuple.format(tuple.actual))
+            return (path: tuple.path, expected: expectedAnyCodable!, actual: actualAnyCodable)
+        }
+        for (index, (path, expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should apply alternate path to matching logic: [\(index)]: test with path=\(path), expected=\(expected), actual=\(actual)") { _ in
+                assertExactMatch(expected: expected, actual: actual, typeMatchPaths: [path])
+                XCTExpectFailure("Validation should fail when using a path without a match") {
+                    assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: [path])
+                }
+            }
+        }
+    }
+
+    func testAlternatePathTypeArray() {
+        let rawCases: [(path: String, expected: Any, actual: Any, format: (Any) -> String)] = [
+            // Validating array format with specific index alternate mode path
+            (path: "[0]", expected: 1, actual: 2, format: { #"[\#($0)]"# }),
+            (path: "[0]", expected: 1.0, actual: 2.0, format: { #"[\#($0)]"# }),
+            (path: "[0]", expected: "a", actual: "b", format: { #"["\#($0)"]"# }),
+            (path: "[0]", expected: true, actual: false, format: { #"[\#($0)]"# }),
+            // Validating array format with wildcard alternate mode path
+            (path: "[*]", expected: 1, actual: 2, format: { #"[\#($0)]"# }),
+            (path: "[*]", expected: 1.0, actual: 2.0, format: { #"[\#($0)]"# }),
+            (path: "[*]", expected: "a", actual: "b", format: { #"["\#($0)"]"# }),
+            (path: "[*]", expected: true, actual: false, format: { #"[\#($0)]"# })
+        ]
+        let testCases = rawCases.map { tuple in
+            let expectedAnyCodable: AnyCodable? = getAnyCodable(tuple.format(tuple.expected))
+            let actualAnyCodable: AnyCodable? = getAnyCodable(tuple.format(tuple.actual))
+            return (path: tuple.path, expected: expectedAnyCodable!, actual: actualAnyCodable)
+        }
+        for (index, (path, expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should apply alternate path to matching logic: [\(index)]: test with path=\(path), expected=\(expected), actual=\(actual)") { _ in
+                assertExactMatch(expected: expected, actual: actual, typeMatchPaths: [path])
+                XCTExpectFailure("Validation should fail when using a path without a match") {
+                    assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: [path])
+                }
+            }
+        }
+    }
+
+    func testSpecialKeyAlternatePath() {
+        let rawCases: [(path: String, expected: Any, actual: Any, format: (Any) -> String)] = [
+            (path: "key1.", expected: 1, actual: 2, format: { #"{ "key1": { "": \#($0) } }"# }), // Nested empty string
+            (path: "key1..key3", expected: 1, actual: 2, format: { #"{ "key1": { "": { "key3": \#($0) } } }"# }), // Non-empty strings surrounding empty string
+            (path: ".key2.", expected: 1, actual: 2, format: { #"{ "": { "key2": { "": \#($0) } } }"# }),// Empty strings surrounding non-empty string
+            (path: "\\\\.", expected: 1, actual: 2, format: { #"{ "\\.": \#($0) }"# }), // Backslash before dot
+            (path: "", expected: 1, actual: 2, format: { #"{ "": \#($0) }"# }),  // Empty key
+            (path: ".", expected: 1, actual: 2, format: { #"{ "": { "": \#($0) } }"# }), // Nested empty keys
+            (path: "...", expected: 1, actual: 2, format: { #"{ "": { "": { "": { "": \#($0) } } } }"# }), // Multiple nested empty keys
+            (path: "\\", expected: 1, actual: 2, format: { #"{ "\\": \#($0) }"# }), // Single backslash
+            (path: "\\\\", expected: 1, actual: 2, format: { #"{ "\\\\": \#($0) }"# }), // Double backslashes
+            (path: "\\.", expected: 1, actual: 2, format: { #"{ ".": \#($0) }"# }), // Backslash before dot
+            (path: "k\\.1\\.2\\.3", expected: 1, actual: 2, format: { #"{ "k.1.2.3": \#($0) }"# }), // Dots in key
+            (path: "k\\.", expected: 1, actual: 2, format: { #"{ "k.": \#($0) }"# }), // Dot at the end of the key
+            (path: "\"", expected: 1, actual: 2, format: { #"{ "\"": \#($0) }"# }), // Escaped double quote
+            (path: "\\'", expected: 1, actual: 2, format: { #"{ "\\'": \#($0) }"# }), // Backslash before single quote
+            (path: "'", expected: 1, actual: 2, format: { #"{ "'": \#($0) }"# }), // Single quote
+            (path: "key with space", expected: 1, actual: 2, format: { #"{ "key with space": \#($0) }"# }), // Space in key
+            (path: "\n", expected: 1, actual: 2, format: { #"{ "\n": \#($0) }"# }), // Control character
+            (path: "key \t \n newline", expected: 1, actual: 2, format: { #"{ "key \t \n newline": \#($0) }"# }), // Control characters in key
+            (path: "안녕하세요", expected: 1, actual: 2, format: { #"{ "안녕하세요": \#($0) }"# }), // Non-Latin characters
+            (path: "a]", expected: 1, actual: 2, format: { #"{ "a]": \#($0) }"# }), // Closing square bracket in key
+            (path: "a[", expected: 1, actual: 2, format: { #"{ "a[": \#($0) }"# }), // Opening square bracket in key
+            (path: "a[1]b", expected: 1, actual: 2, format: { #"{ "a[1]b": \#($0) }"# }), // Array style access in key
+            (path: "key1\\[0\\]", expected: 1, actual: 2, format: { #"{ "key1[0]": \#($0) }"# }), // Array style access at the end of key
+            (path: "\\[1\\][0]", expected: 1, actual: 2, format: { #"{ "[1]": [\#($0)] }"# }), // Array style key then actual array style access
+            (path: "\\[1\\\\][0]", expected: 1, actual: 2, format: { #"{ "[1\\]": [\#($0)] }"# }) // Incomplete array style access then actual array style access
+        ]
+        let testCases = rawCases.map { tuple in
+            let expectedAnyCodable: AnyCodable? = getAnyCodable(tuple.format(tuple.expected))
+            let actualAnyCodable: AnyCodable? = getAnyCodable(tuple.format(tuple.actual))
+            return (path: tuple.path, expected: expectedAnyCodable!, actual: actualAnyCodable)
+        }
+        for (index, (path, expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should handle special keys in alternate paths: [\(index)]: test with path=\(path), expected=\(expected), actual=\(actual)") { _ in
+                assertExactMatch(expected: expected, actual: actual, typeMatchPaths: [path])
+                XCTExpectFailure("Validation should fail when using a path without a match") {
+                    assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: [path])
+                }
+            }
+        }
+    }
+
+    func testExpectedArrayLarger() {
+        let rawCases: [[String]] = [
+            ["[0]"],
+            ["[1]"],
+            ["[0]", "[1]"],
+            ["[*0]"],
+            ["[*1]"],
+            ["[*]"]
+        ]
+        let testCases = rawCases.map { paths in
+            return (paths: paths, expected: getAnyCodable("[1,2]")!, actual: getAnyCodable("[1]"))
+        }
+        for (index, (paths, expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should error on larger expected arrays: [\(index)]: test with paths=\(paths), expected=\(expected), actual=\(actual)") { _ in
+                XCTExpectFailure("Validation should fail when expected array size is larger") {
+                    assertEqual(expected: expected, actual: actual)
+                }
+                XCTExpectFailure("Validation should fail when expected array size is larger") {
+                    assertExactMatch(expected: expected, actual: actual, typeMatchPaths: paths)
+                }
+                XCTExpectFailure("Validation should fail when expected array size is larger") {
+                    assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: paths)
+                }
+            }
+        }
+    }
+
+    func testExpectedDictionaryLarger() {
+        let rawCases: [[String]] = [
+            ["key1"],
+            ["key2"],
+            ["key1", "key2"]
+        ]
+        let testCases = rawCases.map { paths in
+            return (paths: paths,
+                    expected: getAnyCodable(#"{ "key1": 1, "key2": 2 }"#)!,
+                    actual: getAnyCodable(#"{ "key1": 1}"#))
+        }
+        for (index, (paths, expected, actual)) in testCases.enumerated() {
+            XCTContext.runActivity(named: "should error on larger expected maps: [\(index)]: test with paths=\(paths), expected=\(expected), actual=\(actual)") { _ in
+                XCTExpectFailure("Validation should fail when expected dictionary size is larger") {
+                    assertEqual(expected: expected, actual: actual)
+                }
+                XCTExpectFailure("Validation should fail when expected dictionary size is larger") {
+                    assertExactMatch(expected: expected, actual: actual, typeMatchPaths: paths)
+                }
+                XCTExpectFailure("Validation should fail when expected dictionary size is larger") {
+                    assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: paths)
+                }
+            }
+        }
+    }
+}

--- a/Tests/UnitTests/AnyCodableAssertsTests.swift
+++ b/Tests/UnitTests/AnyCodableAssertsTests.swift
@@ -1,0 +1,274 @@
+//
+// Copyright 2023 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import AEPServices
+import AEPTestUtils
+import Foundation
+import XCTest
+
+class AnyCodableAssertsTests: XCTestCase {
+    /// Validates `null` equated to itself is true
+    func testShouldMatchWhenBothValuesAreNil() {
+        let expected: AnyCodable? = nil
+        let actual: AnyCodable? = nil
+        assertEqual(expected: expected, actual: actual)
+    }
+
+    // MARK: - Alternate path tests - assertEqual does not handle alternate paths and is not tested here
+
+    /// Validates alternate path wildcards function independently of order.
+    ///
+    /// - Note: Tests can rely on unique sets of wildcard index values without the need to test
+    /// every variation.
+    func testShouldValidateAlternatePathWildcardOrderIndependence() {
+        let expectedJSONString = """
+        [1, 2]
+        """
+
+        let actualJSONString = """
+        ["a", "b", 1, 2]
+        """
+        let expected = getAnyCodable(expectedJSONString)!
+        let actual = getAnyCodable(actualJSONString)!
+
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[*0]", "[*1]"])
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[*1]", "[*0]"])
+
+        assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[*0]", "[*1]"])
+        assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[*1]", "[*0]"])
+    }
+
+    /// Validates that the wildcard character `*` can only be placed to the left of the index value.
+    func testShouldValidateWildcardIndexFormats() {
+        let expectedJSONString = """
+        [1]
+        """
+
+        let actualJSONString = """
+        ["a", 1]
+        """
+        let expected = getAnyCodable(expectedJSONString)!
+        let actual = getAnyCodable(actualJSONString)!
+
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[*0]"])
+        XCTExpectFailure("Validation should fail when using an invalid wildcard format") {
+            assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[**0]"])
+        }
+        XCTExpectFailure("Validation should fail when using an invalid wildcard format") {
+            assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[0*]"])
+        }
+        XCTExpectFailure("Validation should fail when using an invalid wildcard format") {
+            assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[0*0]"])
+        }
+
+        assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[*0]"])
+        XCTExpectFailure("Validation should fail when using an invalid wildcard format") {
+            assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[**0]"])
+        }
+        XCTExpectFailure("Validation should fail when using an invalid wildcard format") {
+            assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[0*]"])
+        }
+        XCTExpectFailure("Validation should fail when using an invalid wildcard format") {
+            assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[0*0]"])
+        }
+    }
+
+    /// Validates:
+    /// 1. Specific index alternate path checks only against its paired index, as expected.
+    /// 2. Wildcard index allows for matching other positions.
+    func testShouldMatchSpecificIndexToPairedIndexAndWildcardToAnyPosition() {
+        let expectedJSONString = """
+        [1]
+        """
+
+        let actualJSONString = """
+        ["a", 1]
+        """
+        let expected = getAnyCodable(expectedJSONString)!
+        let actual = getAnyCodable(actualJSONString)!
+
+        XCTExpectFailure("Validation should fail when matching using a specific index path without a match") {
+            assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[0]"])
+        }
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[*]"])
+
+        XCTExpectFailure("Validation should fail when matching using a specific index path without a match") {
+            assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[0]"])
+        }
+        assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[*]"])
+    }
+
+    /// Validates standard index matches take precedence over wildcard matches.
+    ///
+    /// - Note: Specifically, this checks the value at `actual[1]` is not first matched to the wildcard and
+    /// fails to satisfy the unspecified index `expected[1]`.
+    func testShouldPrioritizeStandardIndexMatchesOverWildcardMatches() {
+        let expectedJSONString = """
+        [1, 1]
+        """
+
+        let actualJSONString = """
+        ["a", 1, 1]
+        """
+        let expected = getAnyCodable(expectedJSONString)!
+        let actual = getAnyCodable(actualJSONString)!
+
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[*0]"])
+        assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[*0]"])
+    }
+
+    /// Validates:
+    /// 1. Specific index alternate paths should correctly match their corresponding indexes.
+    /// 2. Wildcard matching should correctly match with any appropriate index.
+    func testShouldMatchSpecificIndexesAndAlignWildcardsWithAppropriateIndexes() {
+        let expectedJSONString = """
+        [1, 2]
+        """
+
+        let actualJSONString = """
+        [4, 3, 2, 1]
+        """
+        let expected = getAnyCodable(expectedJSONString)!
+        let actual = getAnyCodable(actualJSONString)!
+
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[0]", "[1]"])
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[*]"])
+
+        XCTExpectFailure("Validation should fail when matching using multiple specific index paths without a match") {
+            assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[0]", "[1]"])
+        }
+        assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[*]"])
+    }
+
+    /// Validates that specific index wildcards only apply to the index specified.
+    func testShouldMatchSpecificIndexWildcardToItsDesignatedIndexOnly() {
+        let expectedJSONString = """
+        [1, 2]
+        """
+
+        let actualJSONString = """
+        [1, 3, 2, 1]
+        """
+        let expected = getAnyCodable(expectedJSONString)!
+        let actual = getAnyCodable(actualJSONString)!
+
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[*1]"])
+        assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[*1]"])
+    }
+
+    /// Validates that array-style access chained with key-value style access functions correctly.
+    /// This covers both specific index and wildcard index styles.
+    func testShouldCorrectlyChainArrayStyleWithKeyValueAccess() {
+        let expectedJSONString = """
+        [
+            {
+                "key1": 1,
+                "key2": 2,
+                "key3": 3
+            }
+        ]
+        """
+
+        let actualJSONString = """
+        [
+            {
+                "key1": 1,
+                "key2": 2,
+                "key3": 3
+            }
+        ]
+        """
+
+        let expected = getAnyCodable(expectedJSONString)!
+        let actual = getAnyCodable(actualJSONString)!
+
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[0].key1"])
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[*].key1"])
+
+        assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[0].key1"])
+        assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[*].key1"])
+    }
+
+    /// Validates that chained array-style access functions correctly.
+    func testShouldCorrectlyChainArrayStyleAccess2x() {
+        let expectedJSONString = """
+        [
+            [1]
+        ]
+        """
+
+        let actualJSONString = """
+        [
+            [2]
+        ]
+        """
+
+        let expected = getAnyCodable(expectedJSONString)!
+        let actual = getAnyCodable(actualJSONString)!
+
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[0][0]"])
+
+        XCTExpectFailure("Validation should fail when using a chained specific index path without a match") {
+            assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[0][0]"])
+        }
+    }
+
+    /// Validates that longer chained array-style access functions correctly.
+    func testShouldCorrectlyChainArrayStyleAccess4x() {
+        let expectedJSONString = """
+        [[[[1]]]]
+        """
+
+        let actualJSONString = """
+        [[[[2]]]]
+        """
+
+        let expected = getAnyCodable(expectedJSONString)!
+        let actual = getAnyCodable(actualJSONString)!
+
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["[0][0][0][0]"])
+
+        XCTExpectFailure("Validation should fail when using a chained specific index path without a match") {
+            assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["[0][0][0][0]"])
+        }
+    }
+
+    /// Validates that key-value style access chained with array-style access functions correctly.
+    /// This covers both specific index and wildcard index styles.
+    func testShouldCorrectlyChainKeyValueWithArrayStyleAccess() {
+        let expectedJSONString = """
+        {
+            "key1": [1]
+        }
+        """
+
+        let actualJSONString = """
+        {
+            "key1": [2]
+        }
+        """
+
+        let expected = getAnyCodable(expectedJSONString)!
+        let actual = getAnyCodable(actualJSONString)!
+
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["key1[0]"])
+        assertExactMatch(expected: expected, actual: actual, typeMatchPaths: ["key1[*]"])
+
+        XCTExpectFailure("Validation should fail when using a specific index path without a match") {
+            assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["key1[0]"])
+        }
+        XCTExpectFailure("Validation should fail when using a wildcard path without a match") {
+            assertTypeMatch(expected: expected, actual: actual, exactMatchPaths: ["key1[*]"])
+        }
+    }
+
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
> [!NOTE]
> The unit test cases that validate the JSON comparison tool are not included in this PR to help with the ease of the review process. The changes are already prepared and will be pushed in a followup PR.
## Description

This PR overhauls the comparison option system to create a powerful modular design that allows for easy customizability. Previously, the design relied on a brittle nested dictionary that only allowed for: 
1. Specifying one comparison option
    * Value type/exact match
3. All or nothing mode flipping (that is, no granularity on the scope of comparison options - this node only, entire subtree)

The new design specifically addresses these two points:
1. Comparison options are easily extensible in the current design, relying on the `MultiPathConfig` protocol that provides for the base configuration options
    * New comparison options allow for:
        1. Value type/exact matching
        2. Collection equal count
        3. Wildcard matching
    * Future options could be:
        1. Key and/or value case insensitive compare
        2. Custom comparator functions
        3. Given type or null
        5. Array only equal count
        6. Dictionary only equal count
        7. Dictionary only validate if present in Actual
        8. And more!
2. Granular scope for each option:
    1. This node only
    2. Subtree (this node + all descendants)

The tree is minimally constructed; that is, it only builds the tree out to the paths that are specified and relies on last set defaults for the given portion of the subtree for unspecified nodes. 
1. This requires that the starting node has all the desired defaults set (which is strictly handled by the public APIs)

## Usage
The usage has been refined so that for a given option configuration, multiple paths can easily be constructed with minimal syntax

### Paths
This is possible using overloaded constructors that allow for passing path values as:
1. Array of paths

```swift
let paths = ["[0]", "[1]"]
assertExactMatch(expected: expected, actual: actual, pathOptions: ValueTypeMatch(paths: paths))
```

2. Variadic

```swift
assertExactMatch(expected: expected, actual: actual, pathOptions: ValueTypeMatch(paths: "[*0]", "[*1]"))
```

### Active or not toggle
Each comparison option has a toggle which controls if it is "active" or not for the given node being evaluated
```swift
assertExactMatch(expected: expected, actual: actual, pathOptions: CollectionEqualCount(paths: "[*0]", "[*1]", isActive: true))
```

### Scope
Scope allows the user to control the granularity of how the option applies to the rest of the JSON structure. Two options are currently allowed:
1. Current node only
2. Subtree

```swift
// For single node only
assertExactMatch(expected: expected, actual: actual, pathOptions: CollectionEqualCount(paths: "[*0]", "[*1]", scope: .singleNode))

// For node and all descendants
assertExactMatch(expected: expected, actual: actual, pathOptions: CollectionEqualCount(paths: "[*0]", "[*1]", scope: .subtree))
```

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The primary motivation for this change was to accommodate the new option for `CollectionEqualCount`, allowing users to specify if they want collections (dictionary or array) to strictly validate the expected number of elements instead of the default permissive extensible object/array.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
