### PR TITLE
Add key must be absent option

### DIFF
--- a/Sources/NodeConfig.swift
+++ b/Sources/NodeConfig.swift
@@ -10,7 +10,6 @@
 // governing permissions and limitations under the License.
 //
 
-
 import Foundation
 import XCTest
 
@@ -51,14 +50,14 @@ public struct WildcardMatch: MultiPathConfig {
     public let optionKey: NodeConfig.OptionKey = .wildcardMatch
     public let isActive: Bool
     public let scope: NodeConfig.Scope
-    
+
     /// Initializes a new instance with an array of paths.
     public init(paths: [String?], isActive: Bool = true, scope: NodeConfig.Scope = .singleNode) {
         self.paths = paths
         self.isActive = isActive
         self.scope = scope
     }
-    
+
     /// Variadic initializer allowing multiple string paths.
     public init(paths: String?..., isActive: Bool = true, scope: NodeConfig.Scope = .singleNode) {
         self.init(paths: paths, isActive: isActive, scope: scope)
@@ -78,7 +77,26 @@ public struct CollectionEqualCount: MultiPathConfig {
         self.isActive = isActive
         self.scope = scope
     }
-    
+
+    /// Variadic initializer allowing multiple string paths.
+    public init(paths: String?..., isActive: Bool = true, scope: NodeConfig.Scope = .singleNode) {
+        self.init(paths: paths, isActive: isActive, scope: scope)
+    }
+}
+
+public struct KeyMustBeAbsent: MultiPathConfig {
+    public let paths: [String?]
+    public let optionKey: NodeConfig.OptionKey = .keyMustBeAbsent
+    public let isActive: Bool
+    public let scope: NodeConfig.Scope
+
+    /// Initializes a new instance with an array of paths.
+    public init(paths: [String?], isActive: Bool = true, scope: NodeConfig.Scope = .singleNode) {
+        self.paths = paths
+        self.isActive = isActive
+        self.scope = scope
+    }
+
     /// Variadic initializer allowing multiple string paths.
     public init(paths: String?..., isActive: Bool = true, scope: NodeConfig.Scope = .singleNode) {
         self.init(paths: paths, isActive: isActive, scope: scope)
@@ -91,13 +109,13 @@ public struct ValueExactMatch: MultiPathConfig {
     public let optionKey: NodeConfig.OptionKey = .primitiveExactMatch
     public let isActive: Bool = true
     public let scope: NodeConfig.Scope
-    
+
     /// Initializes a new instance with an array of paths.
     public init(paths: [String?], scope: NodeConfig.Scope = .singleNode) {
         self.paths = paths
         self.scope = scope
     }
-    
+
     /// Variadic initializer allowing multiple string paths.
     public init(paths: String?..., scope: NodeConfig.Scope = .singleNode) {
         self.init(paths: paths, scope: scope)
@@ -116,7 +134,7 @@ public struct ValueTypeMatch: MultiPathConfig {
         self.paths = paths
         self.scope = scope
     }
-    
+
     /// Variadic initializer allowing multiple string paths.
     public init(paths: String?..., scope: NodeConfig.Scope = .singleNode) {
         self.init(paths: paths, scope: scope)
@@ -136,24 +154,25 @@ public class NodeConfig: Hashable {
         /// This node and all descendants should apply the current configuration.
         case subtree
     }
-    
+
     /// Defines the types of configuration options available for nodes.
     public enum OptionKey: String, Hashable, CaseIterable {
         case wildcardMatch
         case collectionEqualCount
         case primitiveExactMatch
+        case keyMustBeAbsent
     }
-    
+
     /// Represents the configuration details for a comparison option
     public struct Config: Hashable {
         /// Flag for is an option is active or not.
         var isActive: Bool
     }
-    
+
     public enum NodeOption {
         case option(OptionKey, Config, Scope)
     }
-    
+
     /// An string representing the name of the node. `nil` refers to the top level object
     let name: String?
     /// Options set specifically for this node.
@@ -175,11 +194,16 @@ public class NodeConfig: Hashable {
         set { options[.collectionEqualCount] = newValue }
     }
 
+    var keyMustBeAbsent: Config {
+        get { options[.keyMustBeAbsent] ?? subtreeOptions[.keyMustBeAbsent]! }
+        set { options[.keyMustBeAbsent] = newValue }
+    }
+
     var primitiveExactMatch: Config {
         get { options[.primitiveExactMatch] ?? subtreeOptions[.primitiveExactMatch]! }
         set { options[.primitiveExactMatch] = newValue }
     }
-    
+
     /// Creates a new node with the given values.
     ///
     /// Make sure to specify **all** OptionKey values for subtreeOptions, especially when the node is intended to be the root.
@@ -198,19 +222,19 @@ public class NodeConfig: Hashable {
             // If key is missing, add a default value
             validatedSubtreeOptions[key] = Config(isActive: false)
         }
-        
+
         self.name = name
         self.options = options
         self.subtreeOptions = validatedSubtreeOptions
         self.children = children
     }
-    
+
     // Implementation of Hashable
     public static func == (lhs: NodeConfig, rhs: NodeConfig) -> Bool {
         // Define equality based on properties of NodeConfig
         return lhs.name == rhs.name &&
-               lhs.options == rhs.options &&
-               lhs.subtreeOptions == rhs.subtreeOptions
+            lhs.options == rhs.options &&
+            lhs.subtreeOptions == rhs.subtreeOptions
     }
 
     public func hash(into hasher: inout Hasher) {
@@ -218,11 +242,11 @@ public class NodeConfig: Hashable {
         hasher.combine(options)
         hasher.combine(subtreeOptions)
     }
-    
+
     func getChild(named name: String?) -> NodeConfig? {
         return children.first(where: { $0.name == name })
     }
-    
+
     /// Resolves a given node's option using the following precedence:
     /// 1. Node's own node-specific option
     /// 2. Parent node's node-specific option
@@ -244,27 +268,29 @@ public class NodeConfig: Hashable {
         switch option {
         case .collectionEqualCount:
             return node?.collectionEqualCount ?? parentNode.collectionEqualCount
+        case .keyMustBeAbsent:
+            return node?.keyMustBeAbsent ?? parentNode.keyMustBeAbsent
         case .primitiveExactMatch:
             return node?.primitiveExactMatch ?? parentNode.primitiveExactMatch
         case .wildcardMatch:
             return node?.wildcardMatch ?? parentNode.wildcardMatch
         }
     }
-    
+
     func createOrUpdateNode(using multiPathConfig: MultiPathConfig) {
         let pathConfigs = multiPathConfig.paths.map({ PathConfig(path: $0, optionKey: multiPathConfig.optionKey, isActive: multiPathConfig.isActive, scope: multiPathConfig.scope) })
         for pathConfig in pathConfigs {
             createOrUpdateNode(using: pathConfig)
         }
     }
-    
+
     // Helper method to create or traverse nodes
     func createOrUpdateNode(using pathConfig: PathConfig) {
         var current = self
-        
+
         let path = pathConfig.path
         let keyPath = getKeyPathComponents(from: path)
-        
+
         // Inline function to find or create a child node
         func findOrCreateChildNode(named name: String) -> NodeConfig {
             let child: NodeConfig
@@ -283,20 +309,19 @@ public class NodeConfig: Hashable {
             let key = key.replacingOccurrences(of: "\\.", with: ".")
             // Extract the string part and array component part(s) from the key string
             let components = extractArrayFormattedComponents(pathComponent: key)
-            
+
             // Process string part of key
             if let stringComponent = components.stringComponent {
                 current = findOrCreateChildNode(named: stringComponent)
             }
-            
+
             // Process array component parts if applicable
             for arrayComponent in components.arrayComponents {
                 // 1. Check for general wildcard case
                 if arrayComponent == "[*]" {
                     // this actually applies to the current node (since the named node is a collection by virtue of it having array components
                     current.options[.wildcardMatch] = Config(isActive: true)
-                }
-                else {
+                } else {
                     // 2. Extract valid indexes, and wildcard status
                     // indexes represent the "named" child elements of arrays
                     guard let indexResult = extractValidWildcardIndex(pathComponent: arrayComponent) else {
@@ -310,7 +335,7 @@ public class NodeConfig: Hashable {
                 }
             }
         }
-        
+
         func propagateSubtreeOptions(for node: NodeConfig) {
             for child in node.children {
                 child.subtreeOptions = node.subtreeOptions
@@ -322,23 +347,22 @@ public class NodeConfig: Hashable {
         let key = pathConfig.optionKey
         let config = Config(isActive: pathConfig.isActive)
         let scope = pathConfig.scope
-        
+
         if scope == .subtree {
             current.subtreeOptions[key] = config
             // Propagate this subtree option update to all children
             propagateSubtreeOptions(for: current)
-        }
-        else {
+        } else {
             current.options[key] = config
         }
     }
-    
-    
+
     func asFinalNode() -> NodeConfig {
-        // should not modify since other function calls may still depend on children - return a new instance with the values set
-        return NodeConfig(name: nil, options: options, subtreeOptions: subtreeOptions)
+        // Should not modify self since other recursive function calls may still depend on children.
+        // Instead, return a new instance with the proper values set
+        return NodeConfig(name: nil, options: [:], subtreeOptions: subtreeOptions)
     }
-    
+
     /// Extracts and returns a tuple with a valid index and a flag indicating whether it's a wildcard index from a single path component.
     ///
     /// This method considers a key that matches the array access format (ex: `[*123]` or `[123]`).
@@ -374,7 +398,7 @@ public class NodeConfig: Hashable {
 
         return (validIndex, isWildcard)
     }
-    
+
     /// Finds all matches of the `regexPattern` in the `text` and for each match, returns the original matched `String`
     /// and its corresponding non-null capture groups.
     ///
@@ -421,7 +445,7 @@ public class NodeConfig: Hashable {
 
         return captureGroups
     }
-    
+
     /// Extracts and returns the components of a given key path string.
     ///
     /// The method is designed to handle key paths in a specific style such as "key0\.key1.key2[1][2].key3", which represents
@@ -476,7 +500,7 @@ public class NodeConfig: Hashable {
 
         return segments
     }
-    
+
     /// Extracts valid array format access components from a given path component and returns the separated components.
     ///
     /// Given `"key1[0][1]"`, the result is `["key1", "[0]", "[1]"]`.
@@ -492,7 +516,7 @@ public class NodeConfig: Hashable {
     func extractArrayFormattedComponents(pathComponent: String) -> (stringComponent: String?, arrayComponents: [String]) {
         // Handle edge case where input is empty
         if pathComponent.isEmpty { return (stringComponent: "", arrayComponents: []) }
-        
+
         var stringComponent: String = ""
         var arrayComponents: [String] = []
         var bracketCount = 0
@@ -546,8 +570,8 @@ public class NodeConfig: Hashable {
         }
         if !stringComponent.isEmpty {
             stringComponent = stringComponent
-                                .replacingOccurrences(of: "\\[", with: "[")
-                                .replacingOccurrences(of: "\\]", with: "]")
+                .replacingOccurrences(of: "\\[", with: "[")
+                .replacingOccurrences(of: "\\]", with: "]")
         }
         if lastArrayAccessEnd == pathComponent.startIndex {
             return (stringComponent: nil, arrayComponents: arrayComponents)
@@ -569,15 +593,15 @@ extension NodeConfig: CustomStringConvertible {
         result += "\(indentString)Name: \(name ?? "<Unnamed>")\n"
 
         result += "\(indentString)FINAL options:\n"
-        
+
         result += "\(indentString)Equal Count: \(collectionEqualCount)\n"
         result += "\(indentString)Exact Match: \(primitiveExactMatch)\n"
         result += "\(indentString)Wildcard   : \(wildcardMatch)\n"
-        
+
         // Node options
         // Accumulate options in a temporary string
         let sortedOptions = options.sorted { $0.key < $1.key }
-        var optionsDescription = sortedOptions.map { (key, config) in
+        var optionsDescription = sortedOptions.map { key, config in
             "\(indentString)  \(key): \(config)"
         }.joined(separator: "\n")
 
@@ -585,11 +609,11 @@ extension NodeConfig: CustomStringConvertible {
         if !optionsDescription.isEmpty {
             result += "\(indentString)Options:\n" + optionsDescription + "\n"
         }
-        
+
         // Subtree
         // Accumulate options in a temporary string
         let sortedSubtreeOptions = subtreeOptions.sorted { $0.key < $1.key }
-        var subtreeOptionsDescription = sortedSubtreeOptions.map { (key, config) in
+        var subtreeOptionsDescription = sortedSubtreeOptions.map { key, config in
             "\(indentString)  \(key): \(config)"
         }.joined(separator: "\n")
 
@@ -635,6 +659,7 @@ extension NodeConfig.OptionKey: CustomStringConvertible {
         switch self {
         case .wildcardMatch: return "Wildcard   "
         case .collectionEqualCount: return "Equal Count"
+        case .keyMustBeAbsent: return "Key Absent"
         case .primitiveExactMatch: return "Exact Match"
         // Add cases for other options
         }

--- a/Tests/UnitTests/AnyCodableAssertsTests.swift
+++ b/Tests/UnitTests/AnyCodableAssertsTests.swift
@@ -271,4 +271,54 @@ class AnyCodableAssertsTests: XCTestCase, AnyCodableAsserts {
         }
     }
 
+    // MARK: - Path options tests
+    func testKeyMustBeAbsentPasses_whenSinglePath() {
+        let expectedJSONString = """
+        {}
+        """
+
+        let actualJSONString = """
+        {
+            "key1": 1
+        }
+        """
+        let expected = getAnyCodable(expectedJSONString)!
+        let actual = getAnyCodable(actualJSONString)!
+
+        assertExactMatch(expected: expected, actual: actual, pathOptions: KeyMustBeAbsent(paths: "key2"))
+    }
+
+    func testKeyMustBeAbsentPasses_whenMutliplePaths() {
+        let expectedJSONString = """
+        {}
+        """
+
+        let actualJSONString = """
+        {
+            "key1": 1
+        }
+        """
+        let expected = getAnyCodable(expectedJSONString)!
+        let actual = getAnyCodable(actualJSONString)!
+
+        assertExactMatch(expected: expected, actual: actual, pathOptions: KeyMustBeAbsent(paths: "key2", "key3"))
+    }
+
+    func testKeyMustBeAbsentCorrectlyFails_whenKeyPresent() {
+        let expectedJSONString = """
+        {}
+        """
+
+        let actualJSONString = """
+        {
+            "key1": 1
+        }
+        """
+        let expected = getAnyCodable(expectedJSONString)!
+        let actual = getAnyCodable(actualJSONString)!
+
+        XCTExpectFailure("Validation should fail when key that must be absent is present in actual") {
+            assertExactMatch(expected: expected, actual: actual, pathOptions: KeyMustBeAbsent(paths: "key1"))
+        }
+    }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This new JSON comparison option allows test writers to specify key paths whose key names should not be present. It also demonstrates the relative ease of adding new comparison options using the new `NodeConfig` architecture introduced in #9.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
