### PR TITLE
Add `MockExtension` to available helpers

### DIFF
--- a/AEPTestUtils.xcodeproj/project.pbxproj
+++ b/AEPTestUtils.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		4C0293BF2AE1D4550093CCBA /* RealNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0293AE2AE1D4550093CCBA /* RealNetworkService.swift */; };
 		4C0293C02AE1D4550093CCBA /* TestableNetworkRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0293AF2AE1D4550093CCBA /* TestableNetworkRequest.swift */; };
 		4C0293C22AE1D9AD0093CCBA /* XCTestCase+AnyCodableAsserts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0293C12AE1D9AD0093CCBA /* XCTestCase+AnyCodableAsserts.swift */; };
+		4C1111682B64A8F400024172 /* MockExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C1111672B64A8F400024172 /* MockExtension.swift */; };
 		4C7043472AF45A98008CF67D /* EventSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7043462AF45A98008CF67D /* EventSpec.swift */; };
 		4C7043492AF45B05008CF67D /* URL+Testable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7043482AF45B05008CF67D /* URL+Testable.swift */; };
 		4C70434C2AFB0D4F008CF67D /* AnyCodableAssertsParameterizedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C70434A2AFB0D4F008CF67D /* AnyCodableAssertsParameterizedTests.swift */; };
@@ -103,6 +104,7 @@
 		4C0293AE2AE1D4550093CCBA /* RealNetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RealNetworkService.swift; sourceTree = "<group>"; };
 		4C0293AF2AE1D4550093CCBA /* TestableNetworkRequest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestableNetworkRequest.swift; sourceTree = "<group>"; };
 		4C0293C12AE1D9AD0093CCBA /* XCTestCase+AnyCodableAsserts.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+AnyCodableAsserts.swift"; sourceTree = "<group>"; };
+		4C1111672B64A8F400024172 /* MockExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockExtension.swift; sourceTree = "<group>"; };
 		4C7043462AF45A98008CF67D /* EventSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSpec.swift; sourceTree = "<group>"; };
 		4C7043482AF45B05008CF67D /* URL+Testable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Testable.swift"; sourceTree = "<group>"; };
 		4C70434A2AFB0D4F008CF67D /* AnyCodableAssertsParameterizedTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyCodableAssertsParameterizedTests.swift; sourceTree = "<group>"; };
@@ -184,6 +186,7 @@
 				4C0293A02AE1D4540093CCBA /* InstrumentedExtension.swift */,
 				4C0293AD2AE1D4550093CCBA /* MockDataQueue.swift */,
 				4C0293AC2AE1D4550093CCBA /* MockDataStore.swift */,
+				4C1111672B64A8F400024172 /* MockExtension.swift */,
 				4C0293A42AE1D4540093CCBA /* MockHitProcessor.swift */,
 				4C02939F2AE1D4540093CCBA /* MockNetworkService.swift */,
 				4C0293A72AE1D4540093CCBA /* NetworkRequestHelper.swift */,
@@ -464,6 +467,7 @@
 				4C0293B72AE1D4550093CCBA /* TestableExtensionRuntime.swift in Sources */,
 				4C0293B22AE1D4550093CCBA /* FileManager+Testable.swift in Sources */,
 				4CE14ECC2AFDC7F100969B36 /* NodeConfig.swift in Sources */,
+				4C1111682B64A8F400024172 /* MockExtension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/MockExtension.swift
+++ b/Sources/MockExtension.swift
@@ -1,0 +1,60 @@
+//
+// Copyright 2024 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import Foundation
+
+@testable import AEPCore
+
+class MockExtension: Extension {
+    var name = "com.adobe.mockExtension"
+    var friendlyName = "mockExtension"
+    static var extensionVersion = "0.0.1"
+    var metadata: [String: String]?
+
+    static var registrationClosure: (() -> Void)?
+    static var unregistrationClosure: (() -> Void)?
+    static var eventReceivedClosure: ((Event) -> Void)?
+
+    let runtime: ExtensionRuntime
+
+    required init(runtime: ExtensionRuntime) {
+        self.runtime = runtime
+    }
+
+    static func reset() {
+        registrationClosure = nil
+        unregistrationClosure = nil
+        eventReceivedClosure = nil
+    }
+
+    func onRegistered() {
+        registerListener(type: EventType.wildcard, source: EventSource.wildcard) { event in
+            if let closure = type(of: self).eventReceivedClosure {
+                closure(event)
+            }
+        }
+
+        if let closure = type(of: self).registrationClosure {
+            closure()
+        }
+    }
+
+    func onUnregistered() {
+        if let closure = type(of: self).unregistrationClosure {
+            closure()
+        }
+    }
+
+    func readyForEvent(_: Event) -> Bool {
+        return true
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR includes the common `MockExtension` class with the following differences across extensions taken into consideration:

Usages (with Edge Consent's implementation being the reference point):
Edge Media: https://github.com/adobe/aepsdk-edgemedia-ios/blob/d345f22565677d166ca939118426d23ac64ead10/Tests/UnitTests/Utils/MockExtension.swift#L17
* uses NSObject conformance (removing doesn't seem to break anything?)

Messaging: https://github.com/adobe/aepsdk-messaging-ios/blob/da23275cd7891f6f304670c1cd5dee8d6f421768/AEPMessaging/Tests/TestHelpers/MockExtension.swift#L17
* diff: uses implicit return instead of explicit

Target: https://github.com/adobe/aepsdk-target-ios/blob/0232e6bc36e7568245b4b2544076e5d39fbf7e95/AEPTarget/Tests/TestHelpers/MockExtension.swift#L16
* no diff at all

Core: https://github.com/adobe/aepsdk-core-ios/blob/d91de55cd052b1141a5d78d4a4d433fb486c8fac/AEPCore/Tests/MockExtensions/MockExtension.swift#L17
* namespace is `com.adobe.mockExtension` instead of `mockExtension`

Media: https://github.com/adobe/aepsdk-media-ios/blob/b1d37cc100d7f07cde4e06e42123ca74f9686ab7/AEPMedia/Tests/TestHelpers/MockExtension.swift#L16
* Exactly the same

Edge Identity: https://github.com/adobe/aepsdk-edgeidentity-ios/blob/9a03480accb02473829591cb89d7a6de11587a8d/Tests/Mocks/MockExtension.swift#L17
* Exactly the same

Optimize: https://github.com/adobe/aepsdk-optimize-ios/blob/ed7219f2d608e8854db6f82ab8bcb5afaab548d7/Tests/AEPOptimizeTests/UnitTests/Mocks/MockExtension.swift#L15
* properties are `let` instead of `var`
* name is `com.adobe.test.mockExtension`
* friendlyName = "Mock Extension"
* extension version is 1.0.0 instead of 0.0.1
* `runtime` and `init(runtime:)` are reordered in the file

Places: https://github.com/adobe/aepsdk-places-ios/blob/4c6b9116d9fe9d622a56471d95fea15c95bd8fac/AEPPlaces/Tests/Utils/MockExtension.swift#L17
* name is `com.adobe.mockExtension`

Audience: https://github.com/adobe/aepsdk-audience-ios/blob/7fbdc842defb6843ac6d829e04d57d0b78fd5b71/AEPAudience/Tests/TestHelper/MockExtension.swift#L16
* Exactly the same

Analytics: https://github.com/adobe/aepsdk-analytics-ios/blob/372323f4fbded4c98844b42c848e1ef3e5918c2d/AEPAnalytics/Tests/TestHelper/MockExtension.swift#L17
* has NSObject conformance

Campaign: https://github.com/adobe/aepsdk-campaign-ios/blob/aea2e59f2bca56670e6eaf81348af8f74199ae63/AEPCampaign/Tests/TestHelpers/MockExtension.swift#L17
* has NSObject conformance

Campaign Classic: https://github.com/adobe/aepsdk-campaignclassic-ios/blob/b8c631909c6895c13f1028bdd66bfa886f42724f/AEPCampaignClassic/Tests/TestHelpers/MockExtension.swift#L17
* has NSObject conformance

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
