### PR TITLE
Fix swiftlint settings + Fix swiftlint warnings + Fix race conditions in NetworkRequestHelper

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -7,7 +7,6 @@ opt_in_rules: # some rules are opt-in only
 - empty_count
 - empty_string
 - force_unwrapping
-- missing_docs
 - multiline_arguments
 - multiline_function_chains
 - multiline_parameters
@@ -16,6 +15,7 @@ opt_in_rules: # some rules are opt-in only
 - toggle_bool
 - unneeded_parentheses_in_closure_argument
 - vertical_parameter_alignment_on_call
+# - missing_docs
 excluded: # paths to ignore during linting
 - Carthage
 - TestApps/*/Pods
@@ -24,7 +24,7 @@ excluded: # paths to ignore during linting
 analyzer_rules:
  - unused_import
 
-empty_count: 
+empty_count:
     severity: warning
 force_cast: warning
 force_try: warning

--- a/AEPTestUtils.xcodeproj/project.pbxproj
+++ b/AEPTestUtils.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		};
 		D42F36B7251BEBF100490C0D /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -418,7 +419,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [[ -z ${ADB_SKIP_LINT} || ${ADB_SKIP_LINT} -ne \"YES\" ]]; then\n    if which swiftlint >/dev/null; then\n        ./Pods/SwiftLint/swiftlint lint --config ${SRCROOT}/.swiftlint.yml Sources\n    else\n        echo \"warning: SwiftLint is not installed, please run the pod install command from the project root directory.\"\n    fi\nelse\n    echo \"Skipping linting build phase as ADB_SKIP_LINT flag is YES.\"\nfi\n";
+			shellScript = "if [[ -z ${ADB_SKIP_LINT} || ${ADB_SKIP_LINT} -ne \"YES\" ]]; then\n    if which ${PODS_ROOT}/SwiftLint/swiftlint >/dev/null; then\n        ${PODS_ROOT}/SwiftLint/swiftlint lint --config ${SRCROOT}/.swiftlint.yml Sources\n    else\n        echo \"warning: SwiftLint is not installed, please run the pod install command from the project root directory.\"\n    fi\nelse\n    echo \"Skipping linting build phase as ADB_SKIP_LINT flag is YES.\"\nfi\n";
 		};
 		DD86A7F0C226895410FBB282 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/AEPTestUtils.xcodeproj/project.pbxproj
+++ b/AEPTestUtils.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		2E94F8782C179658004BA50D /* NetworkRequest+DeepCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E94F8772C179658004BA50D /* NetworkRequest+DeepCopy.swift */; };
+		2E94F87A2C179679004BA50D /* HttpConnection+DeepCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E94F8792C179679004BA50D /* HttpConnection+DeepCopy.swift */; };
 		4C0293B02AE1D4550093CCBA /* MockNetworkService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C02939F2AE1D4540093CCBA /* MockNetworkService.swift */; };
 		4C0293B12AE1D4550093CCBA /* InstrumentedExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0293A02AE1D4540093CCBA /* InstrumentedExtension.swift */; };
 		4C0293B22AE1D4550093CCBA /* FileManager+TestHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C0293A12AE1D4540093CCBA /* FileManager+TestHelper.swift */; };
@@ -86,6 +88,8 @@
 /* Begin PBXFileReference section */
 		12C2D99438B3AFCC415CE05C /* Pods-AEPTestUtils.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-AEPTestUtils.debug.xcconfig"; path = "Target Support Files/Pods-AEPTestUtils/Pods-AEPTestUtils.debug.xcconfig"; sourceTree = "<group>"; };
 		1E05720B5778E784DC19DA9C /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		2E94F8772C179658004BA50D /* NetworkRequest+DeepCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkRequest+DeepCopy.swift"; sourceTree = "<group>"; };
+		2E94F8792C179679004BA50D /* HttpConnection+DeepCopy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "HttpConnection+DeepCopy.swift"; sourceTree = "<group>"; };
 		34C185B9927DF9E0701D766B /* Pods_AEPTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_AEPTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C02939F2AE1D4540093CCBA /* MockNetworkService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockNetworkService.swift; sourceTree = "<group>"; };
 		4C0293A02AE1D4540093CCBA /* InstrumentedExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InstrumentedExtension.swift; sourceTree = "<group>"; };
@@ -185,6 +189,7 @@
 				4C0293A22AE1D4540093CCBA /* EventHub+TestHelper.swift */,
 				4C7043462AF45A98008CF67D /* EventSpec.swift */,
 				4C0293A12AE1D4540093CCBA /* FileManager+TestHelper.swift */,
+				2E94F8792C179679004BA50D /* HttpConnection+DeepCopy.swift */,
 				4C0293A02AE1D4540093CCBA /* InstrumentedExtension.swift */,
 				4C0293AD2AE1D4550093CCBA /* MockDataQueue.swift */,
 				4C0293AC2AE1D4550093CCBA /* MockDataStore.swift */,
@@ -193,6 +198,7 @@
 				4C02939F2AE1D4540093CCBA /* MockNetworkService.swift */,
 				4CBE65F32B69CD7100EF4600 /* NamedCollectionDataStore+TestHelper.swift */,
 				4C0293A72AE1D4540093CCBA /* NetworkRequestHelper.swift */,
+				2E94F8772C179658004BA50D /* NetworkRequest+DeepCopy.swift */,
 				4CE14ECB2AFDC7F100969B36 /* NodeConfig.swift */,
 				4C0293AE2AE1D4550093CCBA /* RealNetworkService.swift */,
 				4C0293A62AE1D4540093CCBA /* TestableExtensionRuntime.swift */,
@@ -460,11 +466,13 @@
 				4C0293B42AE1D4550093CCBA /* CountDownLatch.swift in Sources */,
 				4C0293C22AE1D9AD0093CCBA /* XCTestCase+AnyCodableAsserts.swift in Sources */,
 				4C0293B82AE1D4550093CCBA /* NetworkRequestHelper.swift in Sources */,
+				2E94F87A2C179679004BA50D /* HttpConnection+DeepCopy.swift in Sources */,
 				4C0293B92AE1D4550093CCBA /* AnyCodable+Array.swift in Sources */,
 				4C0293BE2AE1D4550093CCBA /* MockDataQueue.swift in Sources */,
 				4C0293B02AE1D4550093CCBA /* MockNetworkService.swift in Sources */,
 				4C0293C02AE1D4550093CCBA /* TestableNetworkRequest.swift in Sources */,
 				4C0293B12AE1D4550093CCBA /* InstrumentedExtension.swift in Sources */,
+				2E94F8782C179658004BA50D /* NetworkRequest+DeepCopy.swift in Sources */,
 				4C0293B62AE1D4550093CCBA /* TestUtils.swift in Sources */,
 				4C0293B32AE1D4550093CCBA /* EventHub+TestHelper.swift in Sources */,
 				4C0293BD2AE1D4550093CCBA /* MockDataStore.swift in Sources */,

--- a/Sources/CountDownLatch.swift
+++ b/Sources/CountDownLatch.swift
@@ -45,14 +45,14 @@ public class CountDownLatch {
         if getCurrentCount() == 0 {
             return .success
         }
-        
+
         return self.waitSemaphore.wait(timeout: (DispatchTime.now() + timeout))
     }
 
     public func countDown() {
         queue.sync {
             self.currentCount -= 1
-            
+
             if self.currentCount == 0 {
                 self.waitSemaphore.signal()
             }

--- a/Sources/HttpConnection+DeepCopy.swift
+++ b/Sources/HttpConnection+DeepCopy.swift
@@ -1,0 +1,20 @@
+//
+// Copyright 2024 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import AEPServices
+import Foundation
+
+extension HttpConnection {
+    public func deepCopy() -> HttpConnection {
+        return HttpConnection(data: self.data, response: self.response, error: self.error)
+    }
+}

--- a/Sources/InstrumentedExtension.swift
+++ b/Sources/InstrumentedExtension.swift
@@ -45,13 +45,16 @@ public class InstrumentedExtension: NSObject, Extension {
 
     // MARK: Event Processors
     func wildcardListenerProcessor(_ event: Event) {
-        if event.type.lowercased() == TestConstants.EventType.INSTRUMENTED_EXTENSION.lowercased() {
+        let type = event.type
+        let source = event.source
+
+        if type.lowercased() == TestConstants.EventType.INSTRUMENTED_EXTENSION.lowercased() {
             // process the shared state request event
-            if event.source.lowercased() == TestConstants.EventSource.SHARED_STATE_REQUEST.lowercased() {
+            if source.lowercased() == TestConstants.EventSource.SHARED_STATE_REQUEST.lowercased() {
                 processSharedStateRequest(event)
             }
             // process the unregister extension event
-            else if event.source.lowercased() == TestConstants.EventSource.UNREGISTER_EXTENSION.lowercased() {
+            else if source.lowercased() == TestConstants.EventSource.UNREGISTER_EXTENSION.lowercased() {
                 unregisterExtension()
             }
 
@@ -59,21 +62,23 @@ public class InstrumentedExtension: NSObject, Extension {
         }
 
         // save this event in the receivedEvents dictionary
-        if InstrumentedExtension.receivedEvents[EventSpec(type: event.type, source: event.source)] != nil {
-            InstrumentedExtension.receivedEvents[EventSpec(type: event.type, source: event.source)]?.append(event)
+        if InstrumentedExtension.receivedEvents[EventSpec(type: type, source: source)] != nil {
+            InstrumentedExtension.receivedEvents[EventSpec(type: type, source: source)]?.append(event)
         } else {
-            InstrumentedExtension.receivedEvents[EventSpec(type: event.type, source: event.source)] = [event]
+            InstrumentedExtension.receivedEvents[EventSpec(type: type, source: source)] = [event]
         }
 
         // count down if this is an expected event
-        if InstrumentedExtension.expectedEvents[EventSpec(type: event.type, source: event.source)] != nil {
-            InstrumentedExtension.expectedEvents[EventSpec(type: event.type, source: event.source)]?.countDown()
+        if InstrumentedExtension.expectedEvents[EventSpec(type: type, source: source)] != nil {
+            InstrumentedExtension.expectedEvents[EventSpec(type: type, source: source)]?.countDown()
         }
 
-        if event.source == EventSource.sharedState {
-            Log.debug(label: InstrumentedExtension.logTag, "Received event with type \(event.type) and source \(event.source), state owner \(event.data?["stateowner"] ?? "unknown")")
+        if source == EventSource.sharedState {
+
+            let stateOwner = event.data?["stateowner"] ?? "unknown"
+            Log.debug(label: InstrumentedExtension.logTag, "Received event with type \(type) and source \(source), state owner \(stateOwner)")
         } else {
-            Log.debug(label: InstrumentedExtension.logTag, "Received event with type \(event.type) and source \(event.source)")
+            Log.debug(label: InstrumentedExtension.logTag, "Received event with type \(type) and source \(source)")
         }
     }
 

--- a/Sources/MockDataQueue.swift
+++ b/Sources/MockDataQueue.swift
@@ -15,7 +15,6 @@ import Foundation
 
 /// MockDataQueue - see also AEPServices/Mocks
 public class MockDataQueue: DataQueue {
-    // swiftlint:disable identifier_name
     let queue = ThreadSafeArray<DataEntity>()
 
     public init() {}
@@ -29,12 +28,12 @@ public class MockDataQueue: DataQueue {
         return queue.shallowCopy.first
     }
 
-    public func peek(n: Int) -> [DataEntity]? {
-        return Array(queue.shallowCopy[0..<n])
+    public func peek(n index: Int) -> [DataEntity]? {
+        return Array(queue.shallowCopy[0..<index])
     }
 
-    public func remove(n: Int) -> Bool {
-        guard let results = peek(n: n) else { return true }
+    public func remove(n index: Int) -> Bool {
+        guard let results = peek(n: index) else { return true }
         for result in results {
             _ = queue.filterRemove { $0.uniqueIdentifier == result.uniqueIdentifier }
         }

--- a/Sources/NetworkRequest+DeepCopy.swift
+++ b/Sources/NetworkRequest+DeepCopy.swift
@@ -1,0 +1,25 @@
+//
+// Copyright 2024 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License. You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under
+// the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+// OF ANY KIND, either express or implied. See the License for the specific language
+// governing permissions and limitations under the License.
+//
+
+import AEPServices
+import Foundation
+
+extension NetworkRequest {
+    public func deepCopy() -> NetworkRequest {
+        return NetworkRequest(url: self.url,
+                              httpMethod: self.httpMethod,
+                              connectPayloadData: self.connectPayload,
+                              httpHeaders: self.httpHeaders,
+                              connectTimeout: self.connectTimeout,
+                              readTimeout: self.readTimeout)
+    }
+}

--- a/Sources/NetworkRequestHelper.swift
+++ b/Sources/NetworkRequestHelper.swift
@@ -80,7 +80,7 @@ class NetworkRequestHelper {
             for expectedNetworkRequest in expectedNetworkRequests where expectedNetworkRequest.key == TestableNetworkRequest(from: networkRequest) {
                 return expectedNetworkRequest.value.await(timeout: timeout)
             }
-            
+
             return nil
         }
     }
@@ -96,7 +96,7 @@ class NetworkRequestHelper {
             for request in sentNetworkRequests where request.key == TestableNetworkRequest(from: networkRequest) {
                 return request.value
             }
-            
+
             return []
         }
     }

--- a/Sources/NetworkRequestHelper.swift
+++ b/Sources/NetworkRequestHelper.swift
@@ -21,6 +21,7 @@ import XCTest
 ///    - ``MockNetworkService``
 ///    - ``RealNetworkService``
 class NetworkRequestHelper {
+    private let queue: DispatchQueue = .init(label: "com.adobe.testutils.networkrequesthelper.queue")
     private(set) var orderedNetworkRequests: [NetworkRequest] = []
     private var sentNetworkRequests: [TestableNetworkRequest: [NetworkRequest]] = [:]
     /// Matches sent `NetworkRequest`s with their corresponding `HttpConnection` responses.
@@ -30,33 +31,39 @@ class NetworkRequestHelper {
     func recordSentNetworkRequest(_ networkRequest: NetworkRequest) {
         TestBase.log("Received connectAsync to URL \(networkRequest.url.absoluteString) and HTTPMethod \(networkRequest.httpMethod.toString())")
 
-        // Add to ordered list
-        orderedNetworkRequests.append(networkRequest)
+        queue.sync {
+            // Add to ordered list
+            orderedNetworkRequests.append(networkRequest)
 
-        // Add to grouped collection
-        let testableNetworkRequest = TestableNetworkRequest(from: networkRequest)
-        if let equalNetworkRequest = sentNetworkRequests.first(where: { key, _ in
-            key == testableNetworkRequest
-        }) {
-            sentNetworkRequests[equalNetworkRequest.key]?.append(networkRequest)
-        } else {
-            sentNetworkRequests[testableNetworkRequest] = [networkRequest]
+            // Add to grouped collection
+            let testableNetworkRequest = TestableNetworkRequest(from: networkRequest)
+            if let equalNetworkRequest = sentNetworkRequests.first(where: { key, _ in
+                key == testableNetworkRequest
+            }) {
+                sentNetworkRequests[equalNetworkRequest.key]?.append(networkRequest)
+            } else {
+                sentNetworkRequests[testableNetworkRequest] = [networkRequest]
+            }
         }
     }
 
     func reset() {
-        orderedNetworkRequests.removeAll()
-        expectedNetworkRequests.removeAll()
-        sentNetworkRequests.removeAll()
-        networkResponses.removeAll()
+        queue.sync {
+            orderedNetworkRequests.removeAll()
+            expectedNetworkRequests.removeAll()
+            sentNetworkRequests.removeAll()
+            networkResponses.removeAll()
+        }
     }
 
     /// Decrements the expectation count for a given network request.
     ///
     /// - Parameter networkRequest: The `NetworkRequest` for which the expectation count should be decremented.
     func countDownExpected(networkRequest: NetworkRequest) {
-        for expectedNetworkRequest in expectedNetworkRequests where expectedNetworkRequest.key == TestableNetworkRequest(from: networkRequest) {
-            expectedNetworkRequest.value.countDown()
+        queue.sync {
+            for expectedNetworkRequest in expectedNetworkRequests where expectedNetworkRequest.key == TestableNetworkRequest(from: networkRequest) {
+                expectedNetworkRequest.value.countDown()
+            }
         }
     }
 
@@ -69,11 +76,13 @@ class NetworkRequestHelper {
     ///
     /// - Returns: A `DispatchTimeoutResult` with the result of the wait operation, or `nil` if the `NetworkRequest` does not match any expected request.
     private func awaitFor(networkRequest: NetworkRequest, timeout: TimeInterval) -> DispatchTimeoutResult? {
-        for expectedNetworkRequest in expectedNetworkRequests where expectedNetworkRequest.key == TestableNetworkRequest(from: networkRequest) {
-            return expectedNetworkRequest.value.await(timeout: timeout)
+        queue.sync {
+            for expectedNetworkRequest in expectedNetworkRequests where expectedNetworkRequest.key == TestableNetworkRequest(from: networkRequest) {
+                return expectedNetworkRequest.value.await(timeout: timeout)
+            }
+            
+            return nil
         }
-
-        return nil
     }
 
     ///  Returns all sent network requests that match the provided network request using the
@@ -83,11 +92,13 @@ class NetworkRequestHelper {
     ///
     /// - Returns: An array of `NetworkRequest`s that match the specified `networkRequest`. If no matches are found, an empty array is returned.
     func getSentRequests(matching networkRequest: NetworkRequest) -> [NetworkRequest] {
-        for request in sentNetworkRequests where request.key == TestableNetworkRequest(from: networkRequest) {
-            return request.value
+        queue.sync {
+            for request in sentNetworkRequests where request.key == TestableNetworkRequest(from: networkRequest) {
+                return request.value
+            }
+            
+            return []
         }
-
-        return []
     }
 
     // MARK: - Network response helpers
@@ -98,11 +109,15 @@ class NetworkRequestHelper {
     ///   - responseConnection: The `HttpConnection` to set as a response.
     func addResponse(for networkRequest: NetworkRequest, responseConnection: HttpConnection) {
         let testableNetworkRequest = TestableNetworkRequest(from: networkRequest)
-        if networkResponses[testableNetworkRequest] != nil {
-            networkResponses[testableNetworkRequest]?.append(responseConnection)
-        } else {
-            networkResponses[testableNetworkRequest] = [responseConnection]
+
+        queue.sync {
+            if networkResponses[testableNetworkRequest] != nil {
+                networkResponses[testableNetworkRequest]?.append(responseConnection)
+            } else {
+                networkResponses[testableNetworkRequest] = [responseConnection]
+            }
         }
+
     }
 
     /// Removes all network responses for the provided network request.
@@ -110,8 +125,10 @@ class NetworkRequestHelper {
     /// - Parameters:
     ///   - networkRequest: The `NetworkRequest` for which to remove all responses.
     func removeAllResponses(for networkRequest: NetworkRequest) {
-        let testableNetworkRequest = TestableNetworkRequest(from: networkRequest)
-        networkResponses[testableNetworkRequest] = nil
+        queue.sync {
+            let testableNetworkRequest = TestableNetworkRequest(from: networkRequest)
+            networkResponses[testableNetworkRequest] = nil
+        }
     }
 
     /// Returns the network responses associated with the given network request.
@@ -119,7 +136,9 @@ class NetworkRequestHelper {
     /// - Parameter networkRequest: The `NetworkRequest` for which the response should be retrieved.
     /// - Returns: The array of `HttpConnection` responses associated with the provided `NetworkRequest`, or `nil` if no response was found.
     func getResponses(for networkRequest: NetworkRequest) -> [HttpConnection]? {
-        return networkResponses[TestableNetworkRequest(from: networkRequest)]
+        queue.sync {
+            return networkResponses[TestableNetworkRequest(from: networkRequest)]
+        }
     }
 
     // MARK: Assertion helpers
@@ -137,7 +156,9 @@ class NetworkRequestHelper {
             return
         }
 
-        expectedNetworkRequests[TestableNetworkRequest(from: networkRequest)] = CountDownLatch(expectedCount)
+        queue.sync {
+            expectedNetworkRequests[TestableNetworkRequest(from: networkRequest)] = CountDownLatch(expectedCount)
+        }
     }
 
     /// Asserts that the correct number of network requests were seen for all previously set network request expectations.
@@ -147,75 +168,79 @@ class NetworkRequestHelper {
     /// - SeeAlso:
     ///     - ``setExpectationForNetworkRequest(url:httpMethod:)``
     func assertAllNetworkRequestExpectations(ignoreUnexpectedRequests: Bool = true, file: StaticString = #file, line: UInt = #line) {
-        if expectedNetworkRequests.isEmpty {
-            if !ignoreUnexpectedRequests {
-                assertUnexpectedRequests(file: file, line: line)
+        queue.sync {
+            if expectedNetworkRequests.isEmpty {
+                if !ignoreUnexpectedRequests {
+                    assertUnexpectedRequests(file: file, line: line)
+                }
+                return
             }
-            return
-        }
 
-        for expectedRequest in expectedNetworkRequests {
-            let waitResult = expectedRequest.value.await(timeout: 10)
-            let expectedCount: Int32 = expectedRequest.value.getInitialCount()
-            let receivedCount: Int32 = expectedRequest.value.getInitialCount() - expectedRequest.value.getCurrentCount()
+            for expectedRequest in expectedNetworkRequests {
+                let waitResult = expectedRequest.value.await(timeout: 10)
+                let expectedCount: Int32 = expectedRequest.value.getInitialCount()
+                let receivedCount: Int32 = expectedRequest.value.getInitialCount() - expectedRequest.value.getCurrentCount()
 
-            XCTAssertFalse(waitResult == DispatchTimeoutResult.timedOut,
-                           """
+                XCTAssertFalse(waitResult == DispatchTimeoutResult.timedOut,
+                               """
                            Timed out waiting for network request(s) with URL \(expectedRequest.key.url.absoluteString) and HTTPMethod
                            \(expectedRequest.key.httpMethod.toString()), expected \(expectedCount) but received \(receivedCount)
                            """,
-                           file: file,
-                           line: line)
+                               file: file,
+                               line: line)
 
-            XCTAssertEqual(expectedCount,
-                           receivedCount,
-                           """
+                XCTAssertEqual(expectedCount,
+                               receivedCount,
+                               """
                            Expected \(expectedCount) network request(s) for URL \(expectedRequest.key.url.absoluteString) and HTTPMethod
                            \(expectedRequest.key.httpMethod.toString()), but received \(receivedCount)
                            """,
-                           file: file,
-                           line: line)
+                               file: file,
+                               line: line)
+            }
+            if ignoreUnexpectedRequests { return }
+            assertUnexpectedRequests()
         }
-        if ignoreUnexpectedRequests { return }
-        assertUnexpectedRequests()
     }
 
     func assertUnexpectedRequests(file: StaticString = #file, line: UInt = #line) {
         var unexpectedRequestsCount = 0
         var unexpectedRequestsAsString = ""
+        queue.sync {
 
-        for (sentRequest, requests) in sentNetworkRequests {
-            let sentRequestURL = sentRequest.url.absoluteString
-            let sentRequestHTTPMethod = sentRequest.httpMethod.toString()
-            // Check if request is expected and it is over the expected count
-            if let expectedRequest = expectedNetworkRequests[sentRequest] {
-                _ = expectedRequest.await(timeout: TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT)
-                let expectedCount: Int32 = expectedRequest.getInitialCount()
-                let receivedCount: Int32 = expectedRequest.getInitialCount() - expectedRequest.getCurrentCount()
-                XCTAssertEqual(expectedCount,
-                               receivedCount,
-                               """
+            for (sentRequest, requests) in sentNetworkRequests {
+                let sentRequestURL = sentRequest.url.absoluteString
+                let sentRequestHTTPMethod = sentRequest.httpMethod.toString()
+                // Check if request is expected and it is over the expected count
+                if let expectedRequest = expectedNetworkRequests[sentRequest] {
+                    _ = expectedRequest.await(timeout: TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT)
+                    let expectedCount: Int32 = expectedRequest.getInitialCount()
+                    let receivedCount: Int32 = expectedRequest.getInitialCount() - expectedRequest.getCurrentCount()
+                    XCTAssertEqual(expectedCount,
+                                   receivedCount,
+                                   """
                                Expected \(expectedCount) network request(s) for URL \(sentRequestURL) and HTTPMethod \(sentRequestHTTPMethod),
                                but received \(receivedCount)
                                """,
-                               file: file,
-                               line: line)
+                                   file: file,
+                                   line: line)
+                }
+                // Check for requests that don't have expectations set
+                else {
+                    unexpectedRequestsCount += requests.count
+                    unexpectedRequestsAsString.append("(\(sentRequestURL), \(sentRequestHTTPMethod), \(requests.count)),")
+                    print("NetworkRequestHelper - Received unexpected network request with URL: \(sentRequestURL) and HTTPMethod: \(sentRequestHTTPMethod)")
+                }
             }
-            // Check for requests that don't have expectations set
-            else {
-                unexpectedRequestsCount += requests.count
-                unexpectedRequestsAsString.append("(\(sentRequestURL), \(sentRequestHTTPMethod), \(requests.count)),")
-                print("NetworkRequestHelper - Received unexpected network request with URL: \(sentRequestURL) and HTTPMethod: \(sentRequestHTTPMethod)")
-            }
-        }
 
-        XCTAssertEqual(0,
-                       unexpectedRequestsCount,
-                       """
+            XCTAssertEqual(0,
+                           unexpectedRequestsCount,
+                           """
                        Received \(unexpectedRequestsCount) unexpected network request(s): \(unexpectedRequestsAsString)
                        """,
-                       file: file,
-                       line: line)
+                           file: file,
+                           line: line)
+        }
     }
 
     /// Returns the network request(s) sent through the Core NetworkService, or empty if none was found.

--- a/Sources/NetworkRequestHelper.swift
+++ b/Sources/NetworkRequestHelper.swift
@@ -55,10 +55,8 @@ class NetworkRequestHelper {
     ///
     /// - Parameter networkRequest: The `NetworkRequest` for which the expectation count should be decremented.
     func countDownExpected(networkRequest: NetworkRequest) {
-        for expectedNetworkRequest in expectedNetworkRequests {
-            if expectedNetworkRequest.key == TestableNetworkRequest(from: networkRequest) {
-                expectedNetworkRequest.value.countDown()
-            }
+        for expectedNetworkRequest in expectedNetworkRequests where expectedNetworkRequest.key == TestableNetworkRequest(from: networkRequest) {
+            expectedNetworkRequest.value.countDown()
         }
     }
 
@@ -71,10 +69,8 @@ class NetworkRequestHelper {
     ///
     /// - Returns: A `DispatchTimeoutResult` with the result of the wait operation, or `nil` if the `NetworkRequest` does not match any expected request.
     private func awaitFor(networkRequest: NetworkRequest, timeout: TimeInterval) -> DispatchTimeoutResult? {
-        for expectedNetworkRequest in expectedNetworkRequests {
-            if expectedNetworkRequest.key == TestableNetworkRequest(from: networkRequest) {
-                return expectedNetworkRequest.value.await(timeout: timeout)
-            }
+        for expectedNetworkRequest in expectedNetworkRequests where expectedNetworkRequest.key == TestableNetworkRequest(from: networkRequest) {
+            return expectedNetworkRequest.value.await(timeout: timeout)
         }
 
         return nil
@@ -87,10 +83,8 @@ class NetworkRequestHelper {
     ///
     /// - Returns: An array of `NetworkRequest`s that match the specified `networkRequest`. If no matches are found, an empty array is returned.
     func getSentRequests(matching networkRequest: NetworkRequest) -> [NetworkRequest] {
-        for request in sentNetworkRequests {
-            if request.key == TestableNetworkRequest(from: networkRequest) {
-                return request.value
-            }
+        for request in sentNetworkRequests where request.key == TestableNetworkRequest(from: networkRequest) {
+            return request.value
         }
 
         return []
@@ -164,16 +158,23 @@ class NetworkRequestHelper {
             let waitResult = expectedRequest.value.await(timeout: 10)
             let expectedCount: Int32 = expectedRequest.value.getInitialCount()
             let receivedCount: Int32 = expectedRequest.value.getInitialCount() - expectedRequest.value.getCurrentCount()
+
             XCTAssertFalse(waitResult == DispatchTimeoutResult.timedOut,
                            """
                            Timed out waiting for network request(s) with URL \(expectedRequest.key.url.absoluteString) and HTTPMethod
                            \(expectedRequest.key.httpMethod.toString()), expected \(expectedCount) but received \(receivedCount)
-                           """, file: file, line: line)
-            XCTAssertEqual(expectedCount, receivedCount,
+                           """,
+                           file: file,
+                           line: line)
+
+            XCTAssertEqual(expectedCount,
+                           receivedCount,
                            """
                            Expected \(expectedCount) network request(s) for URL \(expectedRequest.key.url.absoluteString) and HTTPMethod
                            \(expectedRequest.key.httpMethod.toString()), but received \(receivedCount)
-                           """, file: file, line: line)
+                           """,
+                           file: file,
+                           line: line)
         }
         if ignoreUnexpectedRequests { return }
         assertUnexpectedRequests()
@@ -191,11 +192,14 @@ class NetworkRequestHelper {
                 _ = expectedRequest.await(timeout: TestConstants.Defaults.WAIT_NETWORK_REQUEST_TIMEOUT)
                 let expectedCount: Int32 = expectedRequest.getInitialCount()
                 let receivedCount: Int32 = expectedRequest.getInitialCount() - expectedRequest.getCurrentCount()
-                XCTAssertEqual(expectedCount, receivedCount,
+                XCTAssertEqual(expectedCount,
+                               receivedCount,
                                """
                                Expected \(expectedCount) network request(s) for URL \(sentRequestURL) and HTTPMethod \(sentRequestHTTPMethod),
                                but received \(receivedCount)
-                               """, file: file, line: line)
+                               """,
+                               file: file,
+                               line: line)
             }
             // Check for requests that don't have expectations set
             else {
@@ -205,10 +209,13 @@ class NetworkRequestHelper {
             }
         }
 
-        XCTAssertEqual(0, unexpectedRequestsCount,
+        XCTAssertEqual(0,
+                       unexpectedRequestsCount,
                        """
                        Received \(unexpectedRequestsCount) unexpected network request(s): \(unexpectedRequestsAsString)
-                       """, file: file, line: line)
+                       """,
+                       file: file,
+                       line: line)
     }
 
     /// Returns the network request(s) sent through the Core NetworkService, or empty if none was found.
@@ -269,7 +276,9 @@ class NetworkRequestHelper {
                            """
                            Timed out waiting for network request(s) with URL \(networkRequest.url)
                            and HTTPMethod \(networkRequest.httpMethod.toString())
-                           """, file: file, line: line)
+                           """,
+                           file: file,
+                           line: line)
         } else {
             wait(TestConstants.Defaults.WAIT_TIMEOUT)
         }

--- a/Sources/NetworkRequestHelper.swift
+++ b/Sources/NetworkRequestHelper.swift
@@ -31,7 +31,9 @@ class NetworkRequestHelper {
     func recordSentNetworkRequest(_ networkRequest: NetworkRequest) {
         TestBase.log("Received connectAsync to URL \(networkRequest.url.absoluteString) and HTTPMethod \(networkRequest.httpMethod.toString())")
 
-        queue.sync {
+        queue.async { [weak self] in
+
+            guard let self = self else { return }
             // Add to ordered list
             orderedNetworkRequests.append(networkRequest)
 
@@ -48,7 +50,10 @@ class NetworkRequestHelper {
     }
 
     func reset() {
-        queue.sync {
+        queue.async { [weak self] in
+
+            guard let self = self else { return }
+
             orderedNetworkRequests.removeAll()
             expectedNetworkRequests.removeAll()
             sentNetworkRequests.removeAll()
@@ -60,7 +65,10 @@ class NetworkRequestHelper {
     ///
     /// - Parameter networkRequest: The `NetworkRequest` for which the expectation count should be decremented.
     func countDownExpected(networkRequest: NetworkRequest) {
-        queue.sync {
+        queue.async { [weak self] in
+
+            guard let self = self else { return }
+
             for expectedNetworkRequest in expectedNetworkRequests where expectedNetworkRequest.key == TestableNetworkRequest(from: networkRequest) {
                 expectedNetworkRequest.value.countDown()
             }
@@ -125,7 +133,10 @@ class NetworkRequestHelper {
     /// - Parameters:
     ///   - networkRequest: The `NetworkRequest` for which to remove all responses.
     func removeAllResponses(for networkRequest: NetworkRequest) {
-        queue.sync {
+        queue.async { [weak self] in
+
+            guard let self = self else { return }
+
             let testableNetworkRequest = TestableNetworkRequest(from: networkRequest)
             networkResponses[testableNetworkRequest] = nil
         }

--- a/Sources/NetworkRequestHelper.swift
+++ b/Sources/NetworkRequestHelper.swift
@@ -38,11 +38,9 @@ class NetworkRequestHelper {
 
     var networkResponses: [TestableNetworkRequest: [HttpConnection]] {
         return queue.sync {
-            var copiedResponses: [TestableNetworkRequest: [HttpConnection]] = [:]
-            for (key, value) in _networkResponses {
-                copiedResponses[key] = value.map { $0.deepCopy() }
+            return _networkResponses.mapValues { value in
+                return value.map { $0.deepCopy() }
             }
-            return copiedResponses
         }
     }
 
@@ -137,7 +135,7 @@ class NetworkRequestHelper {
         let testableNetworkRequest = TestableNetworkRequest(from: networkRequest)
 
         queue.sync {
-            if networkResponses[testableNetworkRequest] != nil {
+            if _networkResponses[testableNetworkRequest] != nil {
                 _networkResponses[testableNetworkRequest]?.append(responseConnection)
             } else {
                 _networkResponses[testableNetworkRequest] = [responseConnection]
@@ -166,7 +164,7 @@ class NetworkRequestHelper {
     /// - Returns: The array of `HttpConnection` responses associated with the provided `NetworkRequest`, or `nil` if no response was found.
     func getResponses(for networkRequest: NetworkRequest) -> [HttpConnection]? {
         queue.sync {
-            return networkResponses[TestableNetworkRequest(from: networkRequest)]
+            return _networkResponses[TestableNetworkRequest(from: networkRequest)]?.map { $0.deepCopy() }
         }
     }
 

--- a/Sources/NodeConfig.swift
+++ b/Sources/NodeConfig.swift
@@ -153,7 +153,7 @@ public struct ValueTypeMatch: MultiPathConfig {
 /// `NodeConfig` provides a way to set configuration options for nodes in a hierarchical tree structure.
 /// It supports different types of configuration options, including options that apply to individual nodes
 /// or to entire subtrees.
-public class NodeConfig: Hashable {
+public class NodeConfig: Hashable { // swiftlint:disable:this type_body_length
     /// Represents the scope of the configuration; that is, to which nodes the configuration applies.
     public enum Scope: String, Hashable {
         /// Only this node should apply the current configuration.
@@ -206,22 +206,22 @@ public class NodeConfig: Hashable {
     // Property accessors for each option which use the `options` set for the current node
     // and fall back to subtree options.
     var anyOrderMatch: Config {
-        get { options[.anyOrderMatch] ?? subtreeOptions[.anyOrderMatch]! }
+        get { options[.anyOrderMatch] ?? subtreeOptions[.anyOrderMatch]! } // swiftlint:disable:this force_unwrapping
         set { options[.anyOrderMatch] = newValue }
     }
 
     var collectionEqualCount: Config {
-        get { options[.collectionEqualCount] ?? subtreeOptions[.collectionEqualCount]! }
+        get { options[.collectionEqualCount] ?? subtreeOptions[.collectionEqualCount]! } // swiftlint:disable:this force_unwrapping
         set { options[.collectionEqualCount] = newValue }
     }
 
     var keyMustBeAbsent: Config {
-        get { options[.keyMustBeAbsent] ?? subtreeOptions[.keyMustBeAbsent]! }
+        get { options[.keyMustBeAbsent] ?? subtreeOptions[.keyMustBeAbsent]! } // swiftlint:disable:this force_unwrapping
         set { options[.keyMustBeAbsent] = newValue }
     }
 
     var primitiveExactMatch: Config {
-        get { options[.primitiveExactMatch] ?? subtreeOptions[.primitiveExactMatch]! }
+        get { options[.primitiveExactMatch] ?? subtreeOptions[.primitiveExactMatch]! } // swiftlint:disable:this force_unwrapping
         set { options[.primitiveExactMatch] = newValue }
     }
 
@@ -238,7 +238,7 @@ public class NodeConfig: Hashable {
         // Validate subtreeOptions has every option defined
         var validatedSubtreeOptions = subtreeOptions
         for key in OptionKey.allCases {
-            if let foundConfig = subtreeOptions[key] {
+            if subtreeOptions[key] != nil {
                 continue
             }
             // If key is missing, add a default value
@@ -404,13 +404,14 @@ public class NodeConfig: Hashable {
             let components = getArrayPathComponents(from: key)
 
             // Process string segment
-            if var stringComponent = components.stringComponent {
+            if let stringComponent = components.stringComponent {
                 // Check if component is wildcard
                 let isWildcard = stringComponent == "*"
                 if isWildcard {
                     pathComponents.append(PathComponent(name: stringComponent, isAnyOrder: false, isArray: false, isWildcard: isWildcard))
                 } else {
-                    pathComponents.append(PathComponent(name: stringComponent.replacingOccurrences(of: "\\*", with: "*"), isAnyOrder: false, isArray: false, isWildcard: isWildcard))
+                    let cleanStringComponent = stringComponent.replacingOccurrences(of: "\\*", with: "*")
+                    pathComponents.append(PathComponent(name: cleanStringComponent, isAnyOrder: false, isArray: false, isWildcard: isWildcard))
                 }
             }
 
@@ -613,13 +614,14 @@ public class NodeConfig: Hashable {
         segments.append(String(path[startIndex...]))
 
         // Handle edge case where input ends with a dot (but not an escaped dot)
-        if path.hasSuffix(".") && !path.hasSuffix("\\.") && segments.last != "" {
+        if path.hasSuffix(".") && !path.hasSuffix("\\.") && (segments.last ?? "").isEmpty {
             segments.append("")
         }
 
         return segments
     }
 
+    // swiftlint:disable function_body_length
     /// Extracts valid array format access components from a given path component and returns the separated components.
     ///
     /// Given `"key1[0][1]"`, the result is `["key1", "[0]", "[1]"]`.
@@ -697,6 +699,7 @@ public class NodeConfig: Hashable {
         }
         return (stringComponent: stringComponent, arrayComponents: arrayComponents)
     }
+    // swiftlint:enable function_body_length
 }
 
 extension NodeConfig: CustomStringConvertible {
@@ -704,6 +707,7 @@ extension NodeConfig: CustomStringConvertible {
         return describeNode(indentation: 0)
     }
 
+    // swiftlint:disable function_body_length
     private func describeNode(indentation: Int) -> String {
         var result = indentation == 0 ? "\n" : ""
         let indentString = String(repeating: "  ", count: indentation) // Two spaces per indentation level
@@ -737,9 +741,11 @@ extension NodeConfig: CustomStringConvertible {
         // Node options - Only include options where config is TRUE
         let filteredOptions = options.filter { $1.isActive }
         let sortedOptions = filteredOptions.sorted { $0.key < $1.key }
-        var optionsDescription = sortedOptions.map { key, config in
-            "\(indentString)  \(key): \(config)"
-        }.joined(separator: "\n")
+        let optionsDescription = sortedOptions
+            .map { key, config in
+                "\(indentString)  \(key): \(config)"
+            }
+            .joined(separator: "\n")
 
         // Append filtered options to the result if there are any
         if !optionsDescription.isEmpty {
@@ -749,9 +755,11 @@ extension NodeConfig: CustomStringConvertible {
         // Subtree options - Only include options where config is TRUE
         let filteredSubtreeOptions = subtreeOptions.filter { $1.isActive }
         let sortedSubtreeOptions = filteredSubtreeOptions.sorted { $0.key < $1.key }
-        var subtreeOptionsDescription = sortedSubtreeOptions.map { key, config in
-            "\(indentString)  \(key): \(config)"
-        }.joined(separator: "\n")
+        let subtreeOptionsDescription = sortedSubtreeOptions
+            .map { key, config in
+                "\(indentString)  \(key): \(config)"
+            }
+            .joined(separator: "\n")
 
         // Append filtered subtree options to the result if there are any
         if !subtreeOptionsDescription.isEmpty {
@@ -771,6 +779,7 @@ extension NodeConfig: CustomStringConvertible {
 
         return result
     }
+    // swiftlint:enable function_body_length
 }
 
 extension NodeConfig.OptionKey: Comparable {

--- a/Sources/NodeConfig.swift
+++ b/Sources/NodeConfig.swift
@@ -614,7 +614,7 @@ public class NodeConfig: Hashable { // swiftlint:disable:this type_body_length
         segments.append(String(path[startIndex...]))
 
         // Handle edge case where input ends with a dot (but not an escaped dot)
-        if path.hasSuffix(".") && !path.hasSuffix("\\.") && (segments.last ?? "").isEmpty {
+        if path.hasSuffix(".") && !path.hasSuffix("\\.") && !(segments.last ?? "").isEmpty {
             segments.append("")
         }
 

--- a/Sources/TestBase.swift
+++ b/Sources/TestBase.swift
@@ -104,12 +104,17 @@ open class TestBase: XCTestCase {
                            """
                             Timed out waiting for event type \(expectedEvent.key.type) and source \(expectedEvent.key.source),
                             expected \(expectedCount), but received \(receivedCount)
-                            """, file: (file), line: line)
-            XCTAssertEqual(expectedCount, receivedCount,
+                            """,
+                           file: (file),
+                           line: line)
+            XCTAssertEqual(expectedCount,
+                           receivedCount,
                            """
                            Expected \(expectedCount) event(s) of type \(expectedEvent.key.type) and source \(expectedEvent.key.source),
                            but received \(receivedCount)
-                           """, file: (file), line: line)
+                           """,
+                           file: (file),
+                           line: line)
         }
 
         guard ignoreUnexpectedEvents == false else { return }
@@ -131,11 +136,14 @@ open class TestBase: XCTestCase {
                 _ = expectedEvent.await(timeout: TestConstants.Defaults.WAIT_EVENT_TIMEOUT)
                 let expectedCount: Int32 = expectedEvent.getInitialCount()
                 let receivedCount: Int32 = expectedEvent.getInitialCount() - expectedEvent.getCurrentCount()
-                XCTAssertEqual(expectedCount, receivedCount,
+                XCTAssertEqual(expectedCount,
+                               receivedCount,
                                """
                                Expected \(expectedCount) events of type \(receivedEvent.key.type) and source \(receivedEvent.key.source),
                                but received \(receivedCount)
-                               """, file: (file), line: line)
+                               """,
+                               file: (file),
+                               line: line)
             }
             // check for events that don't have expectations set
             else {

--- a/Sources/XCTestCase+AnyCodableAsserts.swift
+++ b/Sources/XCTestCase+AnyCodableAsserts.swift
@@ -1070,7 +1070,7 @@ public extension AnyCodableAsserts where Self: XCTestCase {
                         Actual: \#(actual)
 
                         Key path: \#(keyPathAsString(keyPath))
-                """#,
+                    """#,
                     file: file,
                     line: line)
             }
@@ -1137,7 +1137,7 @@ public extension AnyCodableAsserts where Self: XCTestCase {
                             Actual (remaining unmatched elements): \#(availableWildcardActualIndexes.map({ actual[Int($0)!] }))
 
                             Key path: \#(keyPathAsString(keyPath))
-                    """#,
+                        """#,
                         file: file,
                         line: line)
                 }
@@ -1185,7 +1185,7 @@ public extension AnyCodableAsserts where Self: XCTestCase {
                         Actual: \#(String(describing: actual))
 
                         Key path: \#(keyPathAsString(keyPath))
-                """#,
+                    """#,
                     file: file,
                     line: line)
             }
@@ -1205,7 +1205,7 @@ public extension AnyCodableAsserts where Self: XCTestCase {
                         Actual: \#(actual)
 
                         Key path: \#(keyPathAsString(keyPath))
-                """#,
+                    """#,
                     file: file,
                     line: line)
             }
@@ -1377,7 +1377,7 @@ public extension AnyCodableAsserts where Self: XCTestCase {
                         Actual: \#(actual)
 
                         Key path: \#(keyPathAsString(keyPath))
-                """#,
+                    """#,
                     file: file,
                     line: line)
                 validationResult = false

--- a/Sources/XCTestCase+AnyCodableAsserts.swift
+++ b/Sources/XCTestCase+AnyCodableAsserts.swift
@@ -427,13 +427,14 @@ public extension AnyCodableAsserts where Self: XCTestCase {
             return
         }
         guard let expected = expected, let actual = actual else {
-            XCTFail(#"""
-                \#(expected == nil ? "Expected is nil" : "Actual is nil") and \#(expected == nil ? "Actual" : "Expected") is non-nil.
-
-                Expected: \#(String(describing: expected))
-
-                Actual: \#(String(describing: actual))
-            """#, file: file, line: line)
+            XCTFail(
+                #"""
+                    \#(expected == nil ? "Expected is nil" : "Actual is nil") and \#(expected == nil ? "Actual" : "Expected") is non-nil.
+                    Expected: \#(String(describing: expected))
+                    Actual: \#(String(describing: actual))
+                """#,
+                file: file,
+                line: line)
             return
         }
         // Exact equality is just a special case of exact match
@@ -869,6 +870,7 @@ public extension AnyCodableAsserts where Self: XCTestCase {
         assertExactMatch(expected: expected, actual: actual, pathOptions: pathOptions, file: file, line: line)
     }
 
+    // swiftlint:disable function_parameter_count
     private func validate(
         expected: AnyCodableComparable,
         actual: AnyCodableComparable?,
@@ -892,8 +894,10 @@ public extension AnyCodableAsserts where Self: XCTestCase {
         _ = validateActual(actual: actual, nodeTree: nodeTree, file: file, line: line)
         validateJSON(expected: expected, actual: actual, nodeTree: nodeTree, file: file, line: line)
     }
+    // swiftlint:enable function_parameter_count
 
     // MARK: - AnyCodable validation helpers
+    // swiftlint:disable function_body_length
     /// Performs a cutomizable validation between the given `expected` and `actual` values, using the configured options.
     /// In case of a validation failure **and** if `shouldAssert` is `true`, a test failure occurs.
     ///
@@ -921,19 +925,23 @@ public extension AnyCodableAsserts where Self: XCTestCase {
         }
         guard let expected = expected, let actual = actual else {
             if shouldAssert {
-                XCTFail(#"""
-                    Expected JSON is non-nil but Actual JSON is nil.
+                XCTFail(
+                    #"""
+                        Expected JSON is non-nil but Actual JSON is nil.
 
-                    Expected: \#(String(describing: expected))
+                        Expected: \#(String(describing: expected))
 
-                    Actual: \#(String(describing: actual))
+                        Actual: \#(String(describing: actual))
 
-                    Key path: \#(keyPathAsString(keyPath))
-                """#, file: file, line: line)
+                        Key path: \#(keyPathAsString(keyPath))
+                    """#,
+                    file: file,
+                    line: line)
             }
             return false
         }
 
+        // swiftlint:disable no_fallthrough_only
         switch (expected, actual) {
         case let (expected, actual) where (expected.value is String && actual.value is String):
             fallthrough
@@ -989,17 +997,21 @@ public extension AnyCodableAsserts where Self: XCTestCase {
                 line: line)
         default:
             if shouldAssert {
-                XCTFail(#"""
-                    Expected and Actual types do not match.
+                XCTFail(
+                    #"""
+                        Expected and Actual types do not match.
 
-                    Expected: \#(expected)
+                        Expected: \#(expected)
 
-                    Actual: \#(actual)
+                        Actual: \#(actual)
 
-                    Key path: \#(keyPathAsString(keyPath))
-                """#, file: file, line: line)
+                        Key path: \#(keyPathAsString(keyPath))
+                    """#,
+                    file: file,
+                    line: line)
             }
             return false
+        // swiftlint:enable no_fallthrough_only
         }
     }
 
@@ -1029,32 +1041,38 @@ public extension AnyCodableAsserts where Self: XCTestCase {
         }
         guard let expected = expected, let actual = actual else {
             if shouldAssert {
-                XCTFail(#"""
-                    Expected JSON is non-nil but Actual JSON is nil.
+                XCTFail(
+                    #"""
+                        Expected JSON is non-nil but Actual JSON is nil.
 
-                    Expected: \#(String(describing: expected))
+                        Expected: \#(String(describing: expected))
 
-                    Actual: \#(String(describing: actual))
+                        Actual: \#(String(describing: actual))
 
-                    Key path: \#(keyPathAsString(keyPath))
-                """#, file: file, line: line)
+                        Key path: \#(keyPathAsString(keyPath))
+                """#,
+                    file: file,
+                    line: line)
             }
             return false
         }
         if nodeTree.collectionEqualCount.isActive ? (expected.count != actual.count) : (expected.count > actual.count) {
             if shouldAssert {
-                XCTFail(#"""
-                    Expected JSON \#(nodeTree.collectionEqualCount.isActive ? "count does not match" : "has more elements than") Actual JSON.
+                XCTFail(
+                    #"""
+                        Expected JSON \#(nodeTree.collectionEqualCount.isActive ? "count does not match" : "has more elements than") Actual JSON.
 
-                    Expected count: \#(expected.count)
-                    Actual count: \#(actual.count)
+                        Expected count: \#(expected.count)
+                        Actual count: \#(actual.count)
 
-                    Expected: \#(expected)
+                        Expected: \#(expected)
 
-                    Actual: \#(actual)
+                        Actual: \#(actual)
 
-                    Key path: \#(keyPathAsString(keyPath))
-                """#, file: file, line: line)
+                        Key path: \#(keyPathAsString(keyPath))
+                """#,
+                    file: file,
+                    line: line)
             }
             return false
         }
@@ -1081,8 +1099,8 @@ public extension AnyCodableAsserts where Self: XCTestCase {
 
         // Validate non-wildcard expected side indexes first, as these don't have
         // position flexibility
-        for (index, config) in expectedIndexes {
-            let intIndex = Int(index)!
+        for (index, _) in expectedIndexes {
+            let intIndex = Int(index)! // swiftlint:disable:this force_unwrapping
             validationResult = validateJSON(
                 expected: expected[intIndex],
                 actual: actual[intIndex],
@@ -1094,31 +1112,36 @@ public extension AnyCodableAsserts where Self: XCTestCase {
                 && validationResult
         }
 
-        for (index, config) in anyOrderIndexes {
-            let intIndex = Int(index)!
+        for (index, _) in anyOrderIndexes {
+            let intIndex = Int(index)! // swiftlint:disable:this force_unwrapping
 
             guard let actualIndex = availableWildcardActualIndexes.first(where: {
                 validateJSON(
                     expected: expected[intIndex],
-                    actual: actual[Int($0)!],
+                    actual: actual[Int($0)!], // swiftlint:disable:this force_unwrapping
                     keyPath: keyPath + [intIndex],
                     nodeTree: nodeTree.getNextNode(for: index),
                     shouldAssert: false)
             }) else {
+                // swiftlint:disable force_unwrapping
                 if shouldAssert {
-                    XCTFail(#"""
-                        Wildcard \#(NodeConfig.resolveOption(.primitiveExactMatch, for: nodeTree.getChild(named: index), parent: nodeTree).isActive ? "exact" : "type")
-                        match found no matches on Actual side satisfying the Expected requirement.
+                    XCTFail(
+                        #"""
+                            Wildcard \#(NodeConfig.resolveOption(.primitiveExactMatch, for: nodeTree.getChild(named: index), parent: nodeTree).isActive ? "exact" : "type")
+                            match found no matches on Actual side satisfying the Expected requirement.
 
-                        Requirement: \#(nodeTree)
+                            Requirement: \#(nodeTree)
 
-                        Expected: \#(expected[intIndex])
+                            Expected: \#(expected[intIndex])
 
-                        Actual (remaining unmatched elements): \#(availableWildcardActualIndexes.map({ actual[Int($0)!] }))
+                            Actual (remaining unmatched elements): \#(availableWildcardActualIndexes.map({ actual[Int($0)!] }))
 
-                        Key path: \#(keyPathAsString(keyPath))
-                    """#, file: file, line: line)
+                            Key path: \#(keyPathAsString(keyPath))
+                    """#,
+                        file: file,
+                        line: line)
                 }
+                // swiftlint:enable force_unwrapping
                 validationResult = false
                 break
             }
@@ -1153,32 +1176,38 @@ public extension AnyCodableAsserts where Self: XCTestCase {
         }
         guard let expected = expected, let actual = actual else {
             if shouldAssert {
-                XCTFail(#"""
-                    Expected JSON is non-nil but Actual JSON is nil.
+                XCTFail(
+                    #"""
+                        Expected JSON is non-nil but Actual JSON is nil.
 
-                    Expected: \#(String(describing: expected))
+                        Expected: \#(String(describing: expected))
 
-                    Actual: \#(String(describing: actual))
+                        Actual: \#(String(describing: actual))
 
-                    Key path: \#(keyPathAsString(keyPath))
-                """#, file: file, line: line)
+                        Key path: \#(keyPathAsString(keyPath))
+                """#,
+                    file: file,
+                    line: line)
             }
             return false
         }
         if nodeTree.collectionEqualCount.isActive ? (expected.count != actual.count) : (expected.count > actual.count) {
             if shouldAssert {
-                XCTFail(#"""
-                    Expected JSON \#(nodeTree.collectionEqualCount.isActive ? "count does not match" : "has more elements than") Actual JSON.
+                XCTFail(
+                    #"""
+                        Expected JSON \#(nodeTree.collectionEqualCount.isActive ? "count does not match" : "has more elements than") Actual JSON.
 
-                    Expected count: \#(expected.count)
-                    Actual count: \#(actual.count)
+                        Expected count: \#(expected.count)
+                        Actual count: \#(actual.count)
 
-                    Expected: \#(expected)
+                        Expected: \#(expected)
 
-                    Actual: \#(actual)
+                        Actual: \#(actual)
 
-                    Key path: \#(keyPathAsString(keyPath))
-                """#, file: file, line: line)
+                        Key path: \#(keyPathAsString(keyPath))
+                """#,
+                    file: file,
+                    line: line)
             }
             return false
         }
@@ -1198,6 +1227,7 @@ public extension AnyCodableAsserts where Self: XCTestCase {
         }
         return validationResult
     }
+    // swiftlint:enable function_body_length
 
     // MARK: - Actual JSON validation
 
@@ -1340,13 +1370,16 @@ public extension AnyCodableAsserts where Self: XCTestCase {
             // Check for keys that must be absent in the current node
             let resolvedKeyMustBeAbsent = NodeConfig.resolveOption(.keyMustBeAbsent, for: nodeTree.getChild(named: key), parent: nodeTree)
             if resolvedKeyMustBeAbsent.isActive {
-                XCTFail(#"""
-                    Actual JSON should not have key with name: \#(key)
+                XCTFail(
+                    #"""
+                        Actual JSON should not have key with name: \#(key)
 
-                    Actual: \#(actual)
+                        Actual: \#(actual)
 
-                    Key path: \#(keyPathAsString(keyPath))
-                """#, file: file, line: line)
+                        Key path: \#(keyPathAsString(keyPath))
+                """#,
+                    file: file,
+                    line: line)
                 validationResult = false
             }
             validationResult = validateActual(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Seeing  race error for NetworkRequestHelper getNetworkResponses when running Edge tests with Thread Sanitizer enabled, so added all the lists interactions (create, modify, update ...) onto a queue.

<img width="949" alt="Screenshot 2024-06-05 at 3 14 49 PM" src="https://github.com/adobe/aepsdk-testutils-ios/assets/4697559/8e4b1150-f38f-4a59-819f-e0c128e431c9">



<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
