### PR TITLE
Fix build failure and disable codecov

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 version: 2.1
 
 orbs: 
-  codecov: codecov/codecov@4.1.0
+  # codecov: codecov/codecov@3.3.0
   macos: circleci/macos@2
 
 # Workflows orchestrate a set of jobs to be run
@@ -110,10 +110,10 @@ jobs:
 
       # Code coverage upload using Codecov
       # See options explanation here: https://docs.codecov.com/docs/codecov-uploader
-      - codecov/upload:
-          flags: ios-tests
-          upload_name: Coverage Report for iOS Tests
-          xtra_args: -c -v --xc --xp iosUnitResults.xcresult
+      # - codecov/upload:
+      #     flags: ios-tests
+      #     upload_name: Coverage Report for iOS Tests
+      #     xtra_args: -c -v --xc --xp iosUnitResults.xcresult
 
   test-tvos:
     macos:
@@ -132,10 +132,10 @@ jobs:
 
       # Code coverage upload using Codecov
       # See options explanation here: https://docs.codecov.com/docs/codecov-uploader
-      - codecov/upload:
-          flags: tvos-tests
-          upload_name: Coverage Report for tvOS Tests
-          xtra_args: -c -v --xc --xp tvosresults.xcresult
+      # - codecov/upload:
+      #     flags: tvos-tests
+      #     upload_name: Coverage Report for tvOS Tests
+      #     xtra_args: -c -v --xc --xp tvosresults.xcresult
 
   build_xcframework_and_app:  
     macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@
 version: 2.1
 
 orbs: 
-  codecov: codecov/codecov@3.3.0
+  codecov: codecov/codecov@4.1.0
   macos: circleci/macos@2
 
 # Workflows orchestrate a set of jobs to be run

--- a/AEPTestUtils.podspec
+++ b/AEPTestUtils.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "AEPTestUtils"
-  s.version          = "5.0.0"
+  s.version          = "5.0.1"
   s.summary          = "Experience Platform test utilities for Adobe Experience Platform Mobile SDK. Written and maintained by Adobe."
 
   s.description      = <<-DESC

--- a/AEPTestUtils.podspec
+++ b/AEPTestUtils.podspec
@@ -18,8 +18,8 @@ Pod::Spec.new do |s|
   s.swift_version = '5.1'
 
   s.pod_target_xcconfig = { 'BUILD_LIBRARY_FOR_DISTRIBUTION' => 'YES' }
-  s.dependency 'AEPCore'
-  s.dependency 'AEPServices'
+  s.dependency 'AEPCore', '>= 5.2.0'
+  s.dependency 'AEPServices', '>= 5.2.0'
 
   s.source_files = 'Sources/**/*.swift'
   s.frameworks   = 'XCTest'

--- a/Package.swift
+++ b/Package.swift
@@ -15,12 +15,12 @@ import PackageDescription
 
 let package = Package(
     name: "AEPTestUtils",
-    platforms: [.iOS(.v11), .tvOS(.v11)],
+    platforms: [.iOS(.v12), .tvOS(.v12)],
     products: [
         .library(name: "AEPTestUtils", targets: ["AEPTestUtils"])
     ],
     dependencies: [
-        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "5.0.0"))
+        .package(url: "https://github.com/adobe/aepsdk-core-ios.git", .upToNextMajor(from: "5.2.0"))
     ],
     targets: [
         .target(name: "AEPTestUtils",

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - AEPCore (5.1.0):
+  - AEPCore (5.2.0):
     - AEPRulesEngine (< 6.0.0, >= 5.0.0)
-    - AEPServices (< 6.0.0, >= 5.1.0)
+    - AEPServices (< 6.0.0, >= 5.2.0)
   - AEPRulesEngine (5.0.0)
-  - AEPServices (5.1.0)
+  - AEPServices (5.2.0)
   - SwiftLint (0.52.0)
 
 DEPENDENCIES:
@@ -18,11 +18,11 @@ SPEC REPOS:
     - SwiftLint
 
 SPEC CHECKSUMS:
-  AEPCore: 55489e1c4e48a88659055f8e96290f2cccce9747
+  AEPCore: db53082c207c28166ed6aa9ae6262a55e95c78aa
   AEPRulesEngine: fe5800653a4bee07b1e41e61b4d5551f0dba557b
-  AEPServices: c38b809c32336f10f773525e65c71a949abe54a7
+  AEPServices: d959143d13fde7e8464c19527df6baacdef765ce
   SwiftLint: 13280e21cdda6786ad908dc6e416afe5acd1fcb7
 
 PODFILE CHECKSUM: 32571636f207eaa4bd8039e18e2c4823e2107c19
 
-COCOAPODS: 1.15.0
+COCOAPODS: 1.14.3

--- a/Sources/FileManager+TestHelper.swift
+++ b/Sources/FileManager+TestHelper.swift
@@ -44,7 +44,7 @@ public extension FileManager {
             do {
                 try self.removeItem(at: URL(fileURLWithPath: "\(url.relativePath)/\(cacheItem.name)", isDirectory: cacheItem.isDirectory))
                 if let dqService = ServiceProvider.shared.dataQueueService as? DataQueueService {
-                    _ = dqService.threadSafeDictionary.removeValue(forKey: cacheItem.name)
+                    _ = dqService.store.removeValue(forKey: cacheItem.name)
                 }
             } catch {
                 Log.error(label: LOG_TAG, "Error removing cache item, with reason: \(error)")


### PR DESCRIPTION
- Fix build failure. 
- Update versions and set minimum core dependency to 5.2.0
- Disable codecov as the current version does not run on M1 machines. 